### PR TITLE
Add interactive user-space installer and uninstall flow

### DIFF
--- a/README.md
+++ b/README.md
@@ -254,29 +254,37 @@ Clone the repository:
 git clone <repo-url>
 ```
 
-Install `src/codex_wrapper.sh` somewhere on your `PATH` as the wrapper binary. For example:
+Run the installer:
 
 ```
-install -m 0755 /path/to/codex-wrapper/src/codex_wrapper.sh ~/.local/bin/codex_wrapper.sh
+cd codex-wrapper
+./install.sh
 ```
 
-Run it directly:
+The installer:
+
+* installs the wrapper as `~/.local/bin/codex`
+* writes uninstall support under `~/.local/share/codex-wrapper/`
+* warns if `~/.local/bin` is not currently positioned to override the existing `codex`
+* can, with your permission, append a managed `codex()` override block to `~/.bashrc`
+
+If you prefer a non-interactive install:
 
 ```
-codex_wrapper.sh [wrapper options] [--] [codex arguments...]
+./install.sh --yes --bashrc yes
 ```
 
-If you want `codex` itself to resolve to the wrapper in your shell, add a small shell function that shadows the real `codex` binary and forwards to the script:
+Run the wrapper directly:
 
-```bash
-codex() {
-	command ~/.local/bin/codex_wrapper.sh "$@"
-}
+```
+codex [wrapper options] [--] [codex arguments...]
 ```
 
-Add that function to your shell startup file, for example `~/.bashrc`.
+Uninstall with:
 
-This keeps the wrapper implementation as a normal executable script on `PATH` while using a tiny shell function only as a command alias layer.
+```
+~/.local/share/codex-wrapper/uninstall.sh
+```
 
 ---
 

--- a/SESSION.md
+++ b/SESSION.md
@@ -4,13 +4,13 @@ Session Start: 2026-03-22
 Session End: none
 Session Status: active
 
-Branch: main
-Active Issue: none
-Stage: plan
-Next Skill: pair
+Branch: 3-add-user-installer
+Active Issue: 3
+Stage: review
+Next Skill: propose
 
 Repository State: dirty
-Validation Status: partial
+Validation Status: passing
 
 Source Of Truth:
 - SPEC.md
@@ -21,13 +21,13 @@ Source Of Truth:
 - .codex/docs/session_template.md
 
 Current Goal:
-Establish a durable repository workflow contract with a live `SESSION.md`, a reusable session template, and aligned top-level agent guidance.
+Add an interactive user-space installer and uninstall flow for the wrapper with opt-in `~/.bashrc` integration.
 
 Last Action:
-Added `AGENTS.md`, reviewed the example session format, and split the session format into a live file plus a reusable template.
+Created issue `#3`, moved the installer work onto `3-add-user-installer`, fixed installer review findings, and reran validation.
 
 Next Action:
-Use `pair` or a follow-on documentation pass to refine any remaining workflow guidance and keep the live session state current.
+Prepare the reviewed installer slice for proposal and delivery.
 
 Open Decisions:
 - none
@@ -36,26 +36,29 @@ Blockers:
 - none
 
 Files In Play:
-- AGENTS.md
+- README.md
 - SESSION.md
-- .codex/docs/session_template.md
-- example_session_file.md
+- install.sh
+- test/helper/common.bash
+- test/install.bats
 
 Validation Summary:
-- `AGENTS.md` points agents to `SESSION.md` as the live handoff record
-- the reusable session template now lives in `.codex/docs/session_template.md`
-- the repository has uncommitted documentation changes by design
+- installer adds user-space install, uninstall, warning/confirmation flow, and managed `~/.bashrc` integration
+- uninstall restores any preexisting user `~/.local/bin/codex`
+- reinstall refreshes the managed `~/.bashrc` block instead of leaving stale managed content
+- test suite and shellcheck are passing
 
 Validation / Commands To Rerun:
 - git status --short
-- sed -n '1,220p' AGENTS.md
-- sed -n '1,220p' SESSION.md
-- sed -n '1,220p' .codex/docs/session_template.md
+- git branch --show-current
+- bats --show-output-of-passing-tests test/install.bats
+- ./test/run-tests.sh
+- shellcheck install.sh src/codex_wrapper.sh
 
 Operational Notes:
-- `SESSION.md` is the live session file in this repo
-- `.codex/docs/session_template.md` is the reusable template
-- keep the live session file short and operational rather than narrative
+- issue tracker: `#3 Add interactive user-space installer and uninstall flow`
+- branch naming is now aligned with the issue-mapped workflow
+- worktree remains dirty because the installer slice is not yet committed
 
 Local Exceptions:
 - none

--- a/install.sh
+++ b/install.sh
@@ -1,0 +1,303 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+script_dir="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+source_wrapper="$script_dir/src/codex_wrapper.sh"
+
+bin_dir="${HOME}/.local/bin"
+target_path="$bin_dir/codex"
+install_root="${HOME}/.local/share/codex-wrapper"
+uninstall_path="${install_root}/uninstall.sh"
+backup_path="${install_root}/original-codex"
+state_path="${install_root}/install-state"
+bashrc_path="${HOME}/.bashrc"
+managed_start="# >>> codex-wrapper managed block >>>"
+managed_end="# <<< codex-wrapper managed block <<<"
+
+assume_yes=0
+install_bashrc_mode=ask
+
+usage() {
+	cat <<'EOF'
+Usage: ./install.sh [--yes] [--bashrc yes|no]
+
+Options:
+  --yes           assume yes for install confirmation prompts
+  --bashrc MODE   choose whether to install the managed ~/.bashrc block
+                  MODE must be "yes" or "no"
+  --help, -h      show this help
+EOF
+}
+
+log() {
+	printf '%s\n' "$*"
+}
+
+warn() {
+	printf 'warning: %s\n' "$*" >&2
+}
+
+die() {
+	printf 'error: %s\n' "$*" >&2
+	exit 1
+}
+
+confirm() {
+	local prompt=${1:?prompt required}
+	local default=${2:-yes}
+	local reply=
+
+	if ((assume_yes)); then
+		return 0
+	fi
+
+	if [[ ! -t 0 ]]; then
+		[[ $default == yes ]] && return 0
+		return 1
+	fi
+
+	case "$default" in
+	yes)
+		read -r -p "$prompt [Y/n] " reply || return 1
+		[[ -z $reply || $reply =~ ^[Yy]([Ee][Ss])?$ ]]
+		;;
+	no)
+		read -r -p "$prompt [y/N] " reply || return 1
+		[[ $reply =~ ^[Yy]([Ee][Ss])?$ ]]
+		;;
+	*)
+		die "invalid confirmation default: $default"
+		;;
+	esac
+}
+
+parse_args() {
+	while (($#)); do
+		case "$1" in
+		--yes)
+			assume_yes=1
+			;;
+		--bashrc)
+			shift
+			(($#)) || die "missing value for --bashrc"
+			case "$1" in
+			yes | no)
+				install_bashrc_mode=$1
+				;;
+			*)
+				die "invalid value for --bashrc: $1"
+				;;
+			esac
+			;;
+		--bashrc=*)
+			case "${1#--bashrc=}" in
+			yes | no)
+				install_bashrc_mode=${1#--bashrc=}
+				;;
+			*)
+				die "invalid value for --bashrc: ${1#--bashrc=}"
+				;;
+			esac
+			;;
+		--help | -h)
+			usage
+			exit 0
+			;;
+		*)
+			die "unknown argument: $1"
+			;;
+		esac
+		shift
+	done
+}
+
+path_entry_index() {
+	local needle=$1
+	local old_ifs=$IFS
+	local index=0 entry
+	IFS=:
+	for entry in $PATH; do
+		if [[ $entry == "$needle" ]]; then
+			IFS=$old_ifs
+			printf '%s\n' "$index"
+			return 0
+		fi
+		index=$((index + 1))
+	done
+	IFS=$old_ifs
+	return 1
+}
+
+needs_precedence_warning() {
+	local codex_path codex_dir local_index codex_index
+
+	path_entry_index "$bin_dir" >/dev/null || return 0
+
+	codex_path="$(command -v codex 2>/dev/null || true)"
+	[[ -n $codex_path ]] || return 1
+	[[ $codex_path == "$target_path" ]] && return 1
+	[[ $codex_path == /* ]] || return 0
+
+	codex_dir="$(dirname "$codex_path")"
+	local_index="$(path_entry_index "$bin_dir" 2>/dev/null || true)"
+	codex_index="$(path_entry_index "$codex_dir" 2>/dev/null || true)"
+
+	[[ -n $local_index && -n $codex_index ]] || return 0
+	((local_index < codex_index)) && return 1
+	return 0
+}
+
+ensure_parent_dirs() {
+	mkdir -p "$bin_dir" "$install_root"
+}
+
+is_installed_wrapper() {
+	[[ -f $target_path ]] || return 1
+	cmp -s "$source_wrapper" "$target_path"
+}
+
+preserve_existing_target() {
+	if [[ ! -e $target_path ]]; then
+		printf 'replaced_existing_target=0\n' >"$state_path"
+		return 0
+	fi
+
+	if is_installed_wrapper; then
+		printf 'replaced_existing_target=0\n' >"$state_path"
+		return 0
+	fi
+
+	cp -f "$target_path" "$backup_path"
+	printf 'replaced_existing_target=1\n' >"$state_path"
+}
+
+install_wrapper() {
+	preserve_existing_target
+	install -m 0755 "$source_wrapper" "$target_path"
+}
+
+write_uninstall_script() {
+	cat >"$uninstall_path" <<EOF
+#!/usr/bin/env bash
+set -euo pipefail
+
+target_path="\${HOME}/.local/bin/codex"
+install_root="\${HOME}/.local/share/codex-wrapper"
+uninstall_path="\${install_root}/uninstall.sh"
+backup_path="\${install_root}/original-codex"
+state_path="\${install_root}/install-state"
+bashrc_path="\${HOME}/.bashrc"
+managed_start="# >>> codex-wrapper managed block >>>"
+managed_end="# <<< codex-wrapper managed block <<<"
+
+remove_managed_block() {
+	[[ -f \$bashrc_path ]] || return 0
+
+	awk -v start="\$managed_start" -v end="\$managed_end" '
+		\$0 == start { skip = 1; next }
+		\$0 == end { skip = 0; next }
+		!skip { print }
+	' "\$bashrc_path" >"\${bashrc_path}.codex-wrapper.tmp"
+	mv "\${bashrc_path}.codex-wrapper.tmp" "\$bashrc_path"
+}
+
+restore_previous_target() {
+	local replaced_existing_target=0
+
+	if [[ -f \$state_path ]]; then
+		# shellcheck disable=SC1090
+		source "\$state_path"
+	fi
+
+	if [[ \${replaced_existing_target:-0} -eq 1 && -f \$backup_path ]]; then
+		install -m 0755 "\$backup_path" "\$target_path"
+	else
+		rm -f "\$target_path"
+	fi
+}
+
+main() {
+	remove_managed_block
+	restore_previous_target
+	rm -f "\$backup_path"
+	rm -f "\$state_path"
+	rm -f "\$uninstall_path"
+	rmdir "\$install_root" 2>/dev/null || true
+	log_root="\${HOME}/.local/share"
+	rmdir "\$log_root" 2>/dev/null || true
+	printf 'Removed codex-wrapper install from %s\n' "\$HOME"
+}
+
+main "\$@"
+EOF
+	chmod 0755 "$uninstall_path"
+}
+
+append_bashrc_block() {
+	local block
+
+	block=$(cat <<EOF
+$managed_start
+codex() {
+	command "\$HOME/.local/bin/codex" "\$@"
+}
+$managed_end
+EOF
+)
+
+	if [[ -f $bashrc_path ]]; then
+		awk -v start="$managed_start" -v end="$managed_end" '
+			$0 == start { skip = 1; next }
+			$0 == end { skip = 0; next }
+			!skip { print }
+		' "$bashrc_path" >"${bashrc_path}.codex-wrapper.tmp"
+		mv "${bashrc_path}.codex-wrapper.tmp" "$bashrc_path"
+	fi
+
+	if [[ -f $bashrc_path && -s $bashrc_path ]]; then
+		printf '\n' >>"$bashrc_path"
+	fi
+	printf '%s\n' "$block" >>"$bashrc_path"
+}
+
+maybe_install_bashrc_block() {
+	case "$install_bashrc_mode" in
+	yes)
+		append_bashrc_block
+		log "Installed managed codex shell block in $bashrc_path"
+		;;
+	no)
+		return 0
+		;;
+	ask)
+		if confirm "Append a managed codex override block to $bashrc_path?" no; then
+			append_bashrc_block
+			log "Installed managed codex shell block in $bashrc_path"
+		else
+			log "Skipped ~/.bashrc changes"
+		fi
+		;;
+	esac
+}
+
+main() {
+	parse_args "$@"
+	[[ -f $source_wrapper ]] || die "wrapper source not found: $source_wrapper"
+
+	if needs_precedence_warning; then
+		warn "$bin_dir is not currently positioned to override the existing codex command."
+		warn "You can still install now and optionally add a managed override block to $bashrc_path."
+		confirm "Proceed with install?" yes || die "install aborted"
+	fi
+
+	ensure_parent_dirs
+	install_wrapper
+	write_uninstall_script
+	maybe_install_bashrc_block
+
+	log "Installed wrapper to $target_path"
+	log "Installed uninstall script to $uninstall_path"
+	log "Open a new shell after install for ~/.bashrc changes to take effect."
+}
+
+main "$@"

--- a/test/helper/common.bash
+++ b/test/helper/common.bash
@@ -8,6 +8,7 @@ setup_test_env() {
   export TEST_LOG_DIR="$TEST_ROOT/log"
   export TEST_PATH="$BATS_TEST_DIRNAME/stubs:$PATH"
   export WRAPPER_PATH="$BATS_TEST_DIRNAME/../src/codex_wrapper.sh"
+  export INSTALLER_PATH="$BATS_TEST_DIRNAME/../install.sh"
   export WRAPPER_RUNNER="$BATS_TEST_DIRNAME/helper/run_wrapper.sh"
   export STUB_SYSTEMD_RUN_EXIT=0
   export STUB_SYSTEMD_RUN_INVOKE_COMMAND=0
@@ -81,6 +82,31 @@ run_wrapper_tty() {
     CODEX_WRAPPER_REAL_CODEX="$BATS_TEST_DIRNAME/stubs/codex" \
     "$WRAPPER_RUNNER" "$@")"
   run script -qefc "$cmd" /dev/null
+}
+
+run_installer() {
+  run env \
+    HOME="$TEST_HOME" \
+    PATH="/usr/bin:/bin" \
+    "$INSTALLER_PATH" "$@"
+}
+
+run_installer_with_input() {
+  local input=$1
+  shift
+  local cmd=
+  cmd="$(quote_cmd env \
+    HOME="$TEST_HOME" \
+    PATH="/usr/bin:/bin" \
+    "$INSTALLER_PATH" "$@")"
+  run bash -lc "printf '%s' $(printf '%q' "$input") | script -qefc $(printf '%q' "$cmd") /dev/null"
+}
+
+run_uninstall() {
+  run env \
+    HOME="$TEST_HOME" \
+    PATH="/usr/bin:/bin" \
+    "$TEST_HOME/.local/share/codex-wrapper/uninstall.sh"
 }
 
 quote_cmd() {

--- a/test/install.bats
+++ b/test/install.bats
@@ -1,0 +1,224 @@
+#!/usr/bin/env bats
+
+load helper/common.bash
+
+setup() {
+  setup_test_env
+}
+
+teardown() {
+  teardown_test_env
+}
+
+@test "installer installs wrapper, uninstall script, and managed bashrc block" {
+  run_installer --yes --bashrc yes
+
+  local target uninstall_path input_value actual_value
+  target="$TEST_HOME/.local/bin/codex"
+  uninstall_path="$TEST_HOME/.local/share/codex-wrapper/uninstall.sh"
+  input_value="argv: ./install.sh --yes --bashrc yes
+stdin_type: non-tty
+stdin_value: <empty>"
+  actual_value="$(cat <<EOF
+status=$status
+target_exists=$(log_file_exists "$target")
+target_executable=$([[ -x $target ]] && printf yes || printf no)
+uninstall_exists=$(log_file_exists "$uninstall_path")
+bashrc_block_count=$(count_lines_matching "codex-wrapper managed block" "$TEST_HOME/.bashrc")
+EOF
+)"
+
+  assert_equal_report \
+    "installer installs wrapper, uninstall script, and managed bashrc block" \
+    "installer invocation" \
+    "$input_value" \
+    "status and install record" \
+    "$(cat <<EOF
+status=0
+target_exists=yes
+target_executable=yes
+uninstall_exists=yes
+bashrc_block_count=2
+EOF
+)" \
+    "status and install record" \
+    "$actual_value"
+}
+
+@test "installer preserves an existing user codex and uninstall restores it" {
+  mkdir -p "$TEST_HOME/.local/bin"
+  cat >"$TEST_HOME/.local/bin/codex" <<'EOF'
+#!/usr/bin/env bash
+printf 'existing-user-codex\n'
+EOF
+  chmod 0755 "$TEST_HOME/.local/bin/codex"
+
+  run_installer --yes --bashrc no
+  [[ $status -eq 0 ]]
+
+  run_uninstall
+
+  local input_value actual_value
+  input_value="argv: existing ~/.local/bin/codex, then install and uninstall
+stdin_type: non-tty
+stdin_value: <empty>"
+  actual_value="$(cat <<EOF
+status=$status
+target_exists=$(log_file_exists "$TEST_HOME/.local/bin/codex")
+restored_output=$("$TEST_HOME/.local/bin/codex")
+backup_exists=$(log_file_exists "$TEST_HOME/.local/share/codex-wrapper/original-codex")
+EOF
+)"
+
+  assert_equal_report \
+    "installer preserves an existing user codex and uninstall restores it" \
+    "install and uninstall sequence" \
+    "$input_value" \
+    "status and restore record" \
+"$(cat <<EOF
+status=0
+target_exists=yes
+restored_output=existing-user-codex
+backup_exists=no
+EOF
+)" \
+    "status and restore record" \
+    "$actual_value"
+}
+
+@test "installer warns and aborts when precedence is wrong and user declines" {
+  run_installer_with_input $'n\n' --bashrc no
+
+  local input_value actual_value
+  input_value="argv: ./install.sh --bashrc no
+stdin_type: tty
+stdin_value: n"
+  actual_value="$(cat <<EOF
+status=$status
+target_exists=$(log_file_exists "$TEST_HOME/.local/bin/codex")
+output_has_warning=$(printf '%s' "$output" | grep -F "warning: $TEST_HOME/.local/bin is not currently positioned" >/dev/null && printf yes || printf no)
+output_has_abort=$(printf '%s' "$output" | grep -F "error: install aborted" >/dev/null && printf yes || printf no)
+EOF
+)"
+
+  assert_equal_report \
+    "installer warns and aborts when precedence is wrong and user declines" \
+    "installer invocation" \
+    "$input_value" \
+    "status and warning record" \
+    "$(cat <<EOF
+status=1
+target_exists=no
+output_has_warning=yes
+output_has_abort=yes
+EOF
+)" \
+    "status and warning record" \
+    "$actual_value"
+}
+
+@test "installer can continue after warning without bashrc changes" {
+  run_installer_with_input $'y\n' --bashrc no
+
+  local input_value actual_value
+  input_value="argv: ./install.sh --bashrc no
+stdin_type: tty
+stdin_value: y"
+  actual_value="$(cat <<EOF
+status=$status
+target_exists=$(log_file_exists "$TEST_HOME/.local/bin/codex")
+bashrc_exists=$(log_file_exists "$TEST_HOME/.bashrc")
+output_has_warning=$(printf '%s' "$output" | grep -F "warning: $TEST_HOME/.local/bin is not currently positioned" >/dev/null && printf yes || printf no)
+EOF
+)"
+
+  assert_equal_report \
+    "installer can continue after warning without bashrc changes" \
+    "installer invocation" \
+    "$input_value" \
+    "status and continue record" \
+    "$(cat <<EOF
+status=0
+target_exists=yes
+bashrc_exists=no
+output_has_warning=yes
+EOF
+)" \
+    "status and continue record" \
+    "$actual_value"
+}
+
+@test "uninstall removes installed files and managed bashrc block" {
+  run_installer --yes --bashrc yes
+  [[ $status -eq 0 ]]
+
+  run_uninstall
+
+  local input_value actual_value
+  input_value="argv: ~/.local/share/codex-wrapper/uninstall.sh
+stdin_type: non-tty
+stdin_value: <empty>"
+  actual_value="$(cat <<EOF
+status=$status
+target_exists=$(log_file_exists "$TEST_HOME/.local/bin/codex")
+uninstall_exists=$(log_file_exists "$TEST_HOME/.local/share/codex-wrapper/uninstall.sh")
+bashrc_block_count=$(count_lines_matching "codex-wrapper managed block" "$TEST_HOME/.bashrc")
+EOF
+)"
+
+  assert_equal_report \
+    "uninstall removes installed files and managed bashrc block" \
+    "uninstall invocation" \
+    "$input_value" \
+    "status and cleanup record" \
+    "$(cat <<EOF
+status=0
+target_exists=no
+uninstall_exists=no
+bashrc_block_count=0
+EOF
+)" \
+    "status and cleanup record" \
+    "$actual_value"
+}
+
+@test "installer rewrites an existing managed bashrc block on reinstall" {
+  mkdir -p "$TEST_HOME"
+  cat >"$TEST_HOME/.bashrc" <<'EOF'
+# user config
+# >>> codex-wrapper managed block >>>
+codex() {
+	command "/tmp/old/codex" "$@"
+}
+# <<< codex-wrapper managed block <<<
+EOF
+
+  run_installer --yes --bashrc yes
+
+  local input_value actual_value
+  input_value="argv: ./install.sh --yes --bashrc yes with stale managed block
+stdin_type: non-tty
+stdin_value: <empty>"
+  actual_value="$(cat <<EOF
+status=$status
+managed_start_count=$(count_lines_matching "^# >>> codex-wrapper managed block >>>$" "$TEST_HOME/.bashrc")
+new_target_count=$(grep -F 'command "$HOME/.local/bin/codex" "$@"' "$TEST_HOME/.bashrc" | wc -l)
+old_target_count=$(count_lines_matching '/tmp/old/codex' "$TEST_HOME/.bashrc")
+EOF
+)"
+
+  assert_equal_report \
+    "installer rewrites an existing managed bashrc block on reinstall" \
+    "installer invocation" \
+    "$input_value" \
+    "status and rewrite record" \
+    "$(cat <<EOF
+status=0
+managed_start_count=1
+new_target_count=1
+old_target_count=0
+EOF
+)" \
+    "status and rewrite record" \
+    "$actual_value"
+}


### PR DESCRIPTION
  ## Summary

  Adds a supported user-space install flow for `codex-wrapper`.

  This change introduces an interactive installer that:
  - installs the wrapper to `~/.local/bin/codex`
  - creates managed uninstall support under `~/.local/share/codex-wrapper/`
  - warns when `~/.local/bin` may not override the existing `codex`
  - optionally appends a managed `codex()` override block to `~/.bashrc` with user permission

  It also adds uninstall behavior that:
  - removes installer-managed artifacts
  - removes only the installer-managed `.bashrc` block
  - restores any preexisting user `~/.local/bin/codex`

  Rerunning the installer refreshes the managed `.bashrc` block instead of leaving stale managed content behind.

  Fixes #3

  ## Validation

  - `bats --show-output-of-passing-tests test/install.bats`
  - `./test/run-tests.sh`
  - `shellcheck install.sh src/codex_wrapper.sh`
  EOF

gh pr create --title "Add interactive user-space installer and uninstall flow" --body-file "## Summary

  Adds a supported user-space install flow for `codex-wrapper`.

  This change introduces an interactive installer that:
  - installs the wrapper to `~/.local/bin/codex`
  - creates managed uninstall support under `~/.local/share/codex-wrapper/`
  - warns when `~/.local/bin` may not override the existing `codex`
  - optionally appends a managed `codex()` override block to `~/.bashrc` with user permission

  It also adds uninstall behavior that:
  - removes installer-managed artifacts
  - removes only the installer-managed `.bashrc` block
  - restores any preexisting user `~/.local/bin/codex`

  Rerunning the installer refreshes the managed `.bashrc` block instead of leaving stale managed content behind.

  Fixes #3

  ## Validation

  - `bats --show-output-of-passing-tests test/install.bats`
  - `./test/run-tests.sh`
  - `shellcheck install.sh src/codex_wrapper.sh`"
