### PR TITLE
Update workflow for approval-based command execution

### DIFF
--- a/.codex/docs/HUMAN_WORKFLOW.md
+++ b/.codex/docs/HUMAN_WORKFLOW.md
@@ -26,6 +26,18 @@ At each step transition, the AI should tell you:
 That handoff is important because it gives you a chance to intervene, redirect,
 or reshape the collaboration before the workflow moves forward.
 
+The human pause points in this workflow are approval checkpoints, not routine
+terminal mechanics.
+
+When the AI reaches an approval checkpoint, it should:
+- make the needed approval explicit
+- present its recommendation
+- present the exact text or action to approve when relevant
+- pause before continuing
+
+After explicit approval, the AI may perform the repetitive terminal steps on
+the human's behalf.
+
 ## The Steps
 
 ### `start`
@@ -59,11 +71,17 @@ The issue should explain:
 - the acceptance criteria
 - the validation expected
 
+The AI should draft the issue content first. The human approves the wording.
+After approval, the AI may create the issue.
+
 ### `branch`
 
 Use `branch` to move the work onto an issue-mapped branch.
 
 Do not do implementation work on `main`.
+
+The AI should propose the branch name and intent first. After approval, the AI
+may create and switch to the branch.
 
 ### `plan`
 
@@ -120,7 +138,11 @@ This is where you check:
 
 Use `propose` to prepare the pull request proposal.
 
-This is the step where the PR title, body, and issue-closing line are drafted.
+This is the step where the commit message, PR title, PR body, and
+issue-closing line are drafted.
+
+This is an approval checkpoint. The human should review and approve or edit the
+proposed text before delivery continues.
 
 ### `deliver`
 
@@ -132,12 +154,19 @@ This step covers:
 - push
 - PR creation
 
+After the human approves the commit message and PR text, the AI may perform the
+mechanical delivery commands.
+
 ### `merge`
 
 Use `merge` when the PR is ready to be merged.
 
 This is a separate step on purpose. Cleanup should not be confused with the
 merge itself.
+
+This is also an approval checkpoint. The AI should summarize merge readiness
+and recommend the merge action. After explicit approval, the AI may perform the
+merge command and continue to cleanup.
 
 ### `cleanup`
 
@@ -166,6 +195,11 @@ without forcing the human to infer the workflow from tool names alone.
 It also leaves room for the human to interrupt, redirect, or refine the next
 slice before the AI continues.
 
+At approval checkpoints, the handoff should identify:
+- what approval is needed
+- the AI's recommendation
+- the exact text or command that will be used after approval
+
 ## How To Work With The AI
 
 The AI is an execution and process partner, not the final authority.
@@ -177,13 +211,14 @@ Use the AI to:
 - implement bounded changes
 - generate validation ideas
 - review patch scope and workflow consistency
+- perform repetitive git and GitHub commands after explicit human approval
 
 The human should retain authority over:
 - what problem is worth solving
 - whether the current slice is the right slice
 - architecture and workflow decisions
 - accepting tradeoffs
-- merging and cleanup decisions when judgment is needed
+- approval of issue text, commit message, PR title/body, and merge actions
 
 ## If You Are Unsure What To Type
 

--- a/.codex/docs/PAIR_WORKFLOW.md
+++ b/.codex/docs/PAIR_WORKFLOW.md
@@ -13,19 +13,17 @@ concept -> spec -> issue -> branch -> plan -> pair -> test -> debug -> review ->
 
 ## Human owns
 
-- `gh issue create`
-- `git switch -c ...`
 - problem framing
 - scope approval
 - final choice on uncontrolled implementation decisions that affect solution
   shape, interfaces, architecture, workflow, compatibility, security,
   persistence, performance, or maintenance
 - review of whether the active slice is still the right slice
-- `git commit`
-- `git push`
-- `gh pr create`
-- `gh pr merge`
-- local cleanup
+- approval of issue wording
+- approval of branch intent
+- approval of commit message
+- approval of PR title and PR body
+- approval of merge action
 
 ## AI owns
 
@@ -37,8 +35,39 @@ concept -> spec -> issue -> branch -> plan -> pair -> test -> debug -> review ->
 - test generation
 - patch review
 - PR drafting
-- cleanup checklist
+- cleanup execution and checklist
 - decision briefs for uncontrolled implementation choices
+- repetitive git and GitHub commands after explicit human approval:
+  - `gh issue create`
+  - `git switch -c ...`
+  - `git add`
+  - `git commit`
+  - `git push`
+  - `gh pr create`
+  - `gh pr merge`
+  - post-merge cleanup
+
+## Approval Checkpoints
+
+The main human pause points should happen at approval checkpoints rather than
+at routine command execution.
+
+At an approval checkpoint, the AI should:
+- make the requested approval explicit
+- provide a recommendation
+- show the exact text or action to be used
+- pause for human approval before continuing
+
+Approval checkpoints normally include:
+- issue wording
+- branch creation intent when needed
+- uncontrolled implementation decisions
+- commit message
+- PR title and PR body
+- merge action
+
+If the terminal environment supports it, the AI may also emit an attention cue
+such as a terminal bell when an approval checkpoint is reached.
 
 ## Collaboration Contract For `pair`
 
@@ -62,6 +91,9 @@ At the end of a `pair` slice, the AI should make the handoff explicit:
 - what remains open
 - the next skill
 - what that next skill will do
+
+When the next step includes an approval checkpoint, the handoff should also
+state exactly what approval will be requested next.
 
 This keeps the human in control of the transition instead of forcing them to
 guess the meaning of the next step name.

--- a/.codex/github/branch/SKILL.md
+++ b/.codex/github/branch/SKILL.md
@@ -8,9 +8,10 @@ Procedure
 ---------
 1. Identify the active issue number.
 2. Choose the branch type and slug.
-3. Create or switch to:
+3. Present the proposed branch name for approval:
 
    `<type>/<issue-number>-<slug>`
 
-4. Never perform implementation work on `main`.
-5. Recommend `plan` as the next skill.
+4. After explicit approval, create or switch to that branch.
+5. Never perform implementation work on `main`.
+6. Recommend `plan` as the next skill.

--- a/.codex/github/deliver/SKILL.md
+++ b/.codex/github/deliver/SKILL.md
@@ -7,13 +7,18 @@ Deliver the current slice from staged patch to reviewable pull request.
 Procedure
 ---------
 1. Verify branch and staged scope readiness.
-2. Commit with issue linkage.
-3. Push the branch.
-4. Create the PR using the prepared proposal.
-5. Update `SESSION.md` as operational state.
-6. End with:
+2. Confirm the commit message, PR title, and PR body were explicitly approved.
+3. Perform the mechanical delivery steps:
+
+   - `git add` as needed
+   - `git commit`
+   - `git push`
+   - `gh pr create`
+
+4. Update `SESSION.md` as operational state.
+5. End with:
 
    - a short summary of what `deliver` completed
    - `Next Skill: merge`
-   - a short explanation that `merge` will merge the review-ready PR once the
-     human is satisfied with the review state
+   - a short explanation that `merge` will request final merge approval and
+     then perform the merge if approved

--- a/.codex/github/full-workflow/SKILL.md
+++ b/.codex/github/full-workflow/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: full-workflow
-description: Use when work needs the complete repository Git and GitHub lifecycle in one procedure: create or identify an issue, create the issue-mapped branch, stage and commit focused changes, push the branch, create a PR that auto-closes the issue, merge it, and clean up local and remote branch state afterward.
+description: Use when work needs the complete repository Git and GitHub lifecycle in one procedure with explicit approval checkpoints: create or identify an issue, create the issue-mapped branch, stage and commit focused changes, push the branch, create a PR that auto-closes the issue, merge it, and clean up local and remote branch state afterward.
 ---
 
 # full-workflow
@@ -16,6 +16,7 @@ Use When
 - the user wants one end-to-end Git/GitHub workflow
 - a tracked implementation slice is ready to move from issue creation through merge
 - issue auto-closing and post-merge cleanup must be handled consistently
+- the user is comfortable approving issue/commit/PR/merge text while the AI performs the mechanics
 
 Inputs
 ------
@@ -35,7 +36,7 @@ Procedure
 
 2. Identify or create the issue
 
-   - If no tracked issue exists, draft and create one with:
+   - If no tracked issue exists, draft one with:
      - Problem
      - Why it matters
      - Scope
@@ -43,7 +44,8 @@ Procedure
      - Acceptance criteria
      - Conformance tests
      - Spec references
-   - Prefer:
+   - Present the title/body for approval.
+   - After approval, prefer:
 
      `gh issue create --title "<title>" --body-file <file>`
 
@@ -54,7 +56,8 @@ Procedure
 
      `<type>/<issue-number>-<slug>`
 
-   - Preferred sequence:
+   - Present the branch name for approval.
+   - Preferred sequence after approval:
 
      `git switch main`
 
@@ -79,6 +82,8 @@ Procedure
 
      `feat(cli): emit deterministic invalid-artifact metadata (#42)`
 
+   - Present the exact commit message for approval before committing.
+
 6. Push the branch
 
    - Push with upstream tracking:
@@ -96,14 +101,16 @@ Procedure
 
      `Closes #<issue-number>`
 
-   - Preferred command:
+   - Present the PR title/body for approval.
+   - Preferred command after approval:
 
      `gh pr create --title "<pr-title>" --body-file <file>`
 
 8. Merge deliberately
 
    - Merge only after review-quality checks, validation, and doc/test updates are complete.
-   - Default merge command:
+   - Present merge readiness and the merge command for approval.
+   - Default merge command after approval:
 
      `gh pr merge --squash --delete-branch`
 
@@ -151,8 +158,8 @@ Return a concise operator-ready summary:
 - Staged scope: paths or logical slice
 - Commit: proposed or created
 - Push: exact command
-- PR: exact `gh pr create` command and closing line
-- Merge: exact `gh pr merge` command
+- PR: exact approved title/body and `gh pr create` command
+- Merge: exact approved `gh pr merge` command
 - Cleanup: exact post-merge commands
 - SESSION.md notes: short summary
 

--- a/.codex/github/issue/SKILL.md
+++ b/.codex/github/issue/SKILL.md
@@ -18,5 +18,7 @@ Procedure
    - validation / conformance checks
    - references
 
-4. Provide or run the `gh issue create` command.
-5. Recommend `branch` as the next skill once the issue exists.
+4. Present the exact issue title/body for approval.
+5. After explicit approval, create the issue with `gh issue create` or show the
+   exact command that will be run.
+6. Recommend `branch` as the next skill once the issue exists.

--- a/.codex/github/merge/SKILL.md
+++ b/.codex/github/merge/SKILL.md
@@ -8,9 +8,11 @@ Procedure
 ---------
 1. Confirm the PR is open and ready to merge.
 2. Confirm issue-closing linkage is present.
-3. Run the chosen merge command, preferring:
+3. Present merge readiness and the exact merge command for approval,
+   preferring:
 
    `gh pr merge <pr-number> --squash --delete-branch`
 
-4. Verify the PR merged and the linked issue closed.
-5. Recommend `cleanup` next.
+4. After explicit approval, run the chosen merge command.
+5. Verify the PR merged and the linked issue closed.
+6. Recommend `cleanup` next.

--- a/.codex/github/propose/SKILL.md
+++ b/.codex/github/propose/SKILL.md
@@ -7,12 +7,16 @@ Prepare the reviewable pull request proposal for the current slice.
 Procedure
 ---------
 1. Verify PR readiness.
-2. Draft a truthful title and body grounded in the diff and validation.
+2. Draft a truthful commit message, PR title, and PR body grounded in the diff
+   and validation.
 3. Include issue-closing linkage.
-4. Provide the PR creation command or body file.
-5. End with:
+4. Present the exact text for human approval and identify this as an approval
+   checkpoint.
+5. Optionally prepare the body file or command that `deliver` will use after
+   approval.
+6. End with:
 
    - a short summary of what `propose` produced
    - `Next Skill: deliver`
-   - a short explanation that `deliver` will verify staged scope, commit,
-     push, and create the PR
+   - a short explanation that `deliver` will verify staged scope and, after
+     approval, perform commit, push, and PR creation

--- a/.codex/github/workflow-helpers/SKILL.md
+++ b/.codex/github/workflow-helpers/SKILL.md
@@ -9,12 +9,12 @@ Procedure
 Use:
 - `gh issue list`
 - `gh issue view <number>`
-- `gh issue create`
+- `gh issue create` after issue-text approval
 - `gh pr list`
 - `gh pr view <number>`
 - `gh pr diff`
-- `gh pr create`
-- `gh pr merge --squash`
+- `gh pr create` after commit/PR-text approval
+- `gh pr merge --squash` after explicit merge approval
 - `gh release create <tag>`
 
 Always pair command suggestions with why the command is the right next step.

--- a/.codex/github/workflow/SKILL.md
+++ b/.codex/github/workflow/SKILL.md
@@ -6,10 +6,11 @@ Manage the GitHub-centered lifecycle: issue -> branch -> PR -> merge.
 
 Procedure
 ---------
-1. Identify or create the relevant issue.
-2. Ensure the branch naming ties back to the issue.
+1. Identify or create the relevant issue using the approval checkpoint model.
+2. Ensure the branch naming ties back to the issue and is approved before branch creation.
 3. Check for spec/design/test linkage in issue or PR context.
 4. Prepare a PR only when patch review, testing, and docs checks are complete.
 5. Ensure the PR summary explains problem, approach, testing, and tradeoffs.
-6. Use `merge` to perform the merge only after review-quality checks are done.
-7. Use `cleanup` only after the merge is confirmed.
+6. Treat commit text, PR text, and merge action as explicit approval checkpoints.
+7. Use `merge` only after review-quality checks are done and merge approval is explicit.
+8. Use `cleanup` only after the merge is confirmed.

--- a/.codex/workflow/pair/SKILL.md
+++ b/.codex/workflow/pair/SKILL.md
@@ -24,7 +24,8 @@ Procedure
 3. Confirm the collaboration split:
 
    - the human owns direction, scope approval, and decision-making
-   - the AI owns bounded execution, status reporting, and explicit escalation
+   - the AI owns bounded execution, status reporting, explicit escalation, and
+     repetitive git/GitHub commands after approval
 
 4. Implement only the controlled behavior for the current slice.
 5. If an uncontrolled decision appears, stop and escalate it clearly instead of

--- a/.codex/workflow/session-handoff/SKILL.md
+++ b/.codex/workflow/session-handoff/SKILL.md
@@ -12,3 +12,5 @@ Procedure
 4. Do not replace the issue/spec/design with session notes.
 5. When the repository is in post-merge cleanup on `main`, it is valid for `SESSION.md` to remain intentionally unstaged as a human review buffer while the rest of the working tree is clean.
 6. If `SESSION.md` is intentionally left unstaged, state that explicitly so the next session does not treat it as accidental dirt.
+7. When an approval checkpoint is pending, record exactly what approval is
+   needed next so the next session can resume at the correct pause point.

--- a/.codex/workflow/spec-to-issue/SKILL.md
+++ b/.codex/workflow/spec-to-issue/SKILL.md
@@ -31,9 +31,11 @@ Procedure
    - spec references
 
 4. Draft a focused issue title and body.
-5. Provide the exact `gh issue create` command needed to create that issue.
-6. Recommend a branch slug and branch type prefix.
-7. Recommend `branch` as the next action once the issue number exists.
+5. Present the draft for human approval.
+6. After approval, provide or run the exact `gh issue create` command needed to
+   create that issue.
+7. Recommend a branch slug and branch type prefix.
+8. Recommend `branch` as the next action once the issue number exists.
 
 Output
 ------
@@ -41,7 +43,7 @@ Return:
 
 Issue Title:
 Issue Body:
-Issue Create Command:
+Approved Issue Create Command:
 Spec References:
 Recommended Branch:
 Next Skill:

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -62,6 +62,7 @@ When operating in this repository:
   - `Next Skill: <name>`
   - a short explanation of what that next skill will do
 - treat human operators as owners of problem framing, scope approval, and final uncontrolled decisions
+- treat approval checkpoints as the main human pause points; after explicit approval, repetitive git and GitHub commands may be AI-executed
 - stop and escalate instead of guessing when a choice affects architecture, interfaces, workflow, compatibility, security, persistence, performance, or maintenance shape
 - keep implementation work on issue-mapped branches rather than `main`
 - treat `SKILL.md` content as the operational source for each step
@@ -71,7 +72,8 @@ When operating in this repository:
 Summarized from `.codex/docs/PAIR_WORKFLOW.md`:
 
 - the human owns direction, scope approval, and final decisions on uncontrolled changes
-- the AI owns bounded execution, status reporting, drafting support, validation guidance, and explicit escalation
+- the human also owns approval of issue text, commit message, PR title/body, and merge actions
+- the AI owns bounded execution, status reporting, drafting support, validation guidance, explicit escalation, and repetitive git/GitHub command execution after approval
 
 If a workflow or skill file conflicts with this summary, follow the more specific source document.
 

--- a/SESSION.md
+++ b/SESSION.md
@@ -1,15 +1,15 @@
 # SESSION
 
 Session Start: 2026-03-22
-Session End: none
-Session Status: active
+Session End: 2026-03-22
+Session Status: complete
 
-Branch: 3-add-user-installer
-Active Issue: 3
-Stage: review
-Next Skill: propose
+Branch: main
+Active Issue: none
+Stage: finish
+Next Skill: start
 
-Repository State: dirty
+Repository State: clean
 Validation Status: passing
 
 Source Of Truth:
@@ -21,13 +21,13 @@ Source Of Truth:
 - .codex/docs/session_template.md
 
 Current Goal:
-Add an interactive user-space installer and uninstall flow for the wrapper with opt-in `~/.bashrc` integration.
+Session closed after merging the installer slice and updating the repository workflow contract.
 
 Last Action:
-Created issue `#3`, moved the installer work onto `3-add-user-installer`, fixed installer review findings, and reran validation.
+Updated the workflow docs and step-specific skill files to use approval checkpoints with AI-executed mechanics after approval.
 
 Next Action:
-Prepare the reviewed installer slice for proposal and delivery.
+Start a new session from `main`, restore context from this file, and follow the updated approval-based workflow.
 
 Open Decisions:
 - none
@@ -36,29 +36,27 @@ Blockers:
 - none
 
 Files In Play:
-- README.md
 - SESSION.md
-- install.sh
-- test/helper/common.bash
-- test/install.bats
 
 Validation Summary:
-- installer adds user-space install, uninstall, warning/confirmation flow, and managed `~/.bashrc` integration
-- uninstall restores any preexisting user `~/.local/bin/codex`
-- reinstall refreshes the managed `~/.bashrc` block instead of leaving stale managed content
-- test suite and shellcheck are passing
+- PR `#4` merged to `main`
+- local branch cleanup is complete
+- local `main` matches remote `main`
+- workflow docs and relevant skill files now align on approval checkpoints and AI-executed mechanics after approval
 
 Validation / Commands To Rerun:
 - git status --short
 - git branch --show-current
-- bats --show-output-of-passing-tests test/install.bats
-- ./test/run-tests.sh
-- shellcheck install.sh src/codex_wrapper.sh
+- gh pr view 4 --json state,mergedAt,mergeCommit,url
+- git pull --ff-only origin main
+- git remote prune origin
+- rg -n "approval checkpoint|after explicit approval|gh pr merge|gh pr create" .codex AGENTS.md
 
 Operational Notes:
-- issue tracker: `#3 Add interactive user-space installer and uninstall flow`
-- branch naming is now aligned with the issue-mapped workflow
-- worktree remains dirty because the installer slice is not yet committed
+- merged issue: `#3 Add interactive user-space installer and uninstall flow`
+- merged PR: `#4`
+- merge commit: `f407a903d00ee93ebf58845570fb1528b30a3287`
+- workflow contract now pauses the human at approval checkpoints rather than routine terminal commands
 
 Local Exceptions:
 - none


### PR DESCRIPTION
## Summary

Updates the repository workflow contract so human pauses happen at explicit approval checkpoints, while the AI may perform repetitive git and GitHub mechanics after approval.

This change updates the top-level workflow docs and relevant step-specific skills so they consistently describe:
- approval checkpoints as the main human pause points
- AI execution of issue creation, branch creation, commit, push, PR creation, merge, and cleanup after explicit approval
- `propose` as the checkpoint for commit message and PR text approval
- `merge` as the checkpoint for merge approval before AI-executed merge

Fixes #5

## Changes

- update `AGENTS.md`
- update human-facing workflow docs in `.codex/docs/`
- update relevant `.codex/**/SKILL.md` files for issue, branch, propose, deliver, merge, workflow helpers, session handoff, and full workflow routing
- record pending approval checkpoints in session-handoff guidance

## Validation

- reviewed workflow docs and skill files for consistency
- searched for stale ownership wording around issue creation, commit, push, PR creation, and merge
- confirmed canonical workflow naming remains unchanged

## Notes

This is a workflow-contract update only. It does not change the canonical step names or relax human control over scope and uncontrolled decisions.
