### PR TITLE
Persist wrapper agent and skill toggle state

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ It provides:
 
 * systemd-based sandboxing
 * explicit read/write path control
-* temporary per-run disabling of repo `AGENTS.md` and skill sources
+* state-setting enable/disable of repo `AGENTS.md` and skill sources
 * automatic interactive vs non-interactive handling
 * safe fallback when sandboxing fails
 * early failure if the configured native Codex executable is missing or not executable
@@ -183,40 +183,37 @@ codex --no-skills
 codex --no-skags
 ```
 
-`--agents` temporarily rename matching `AGENTS.md.disabled` entries under the
-current `PWD` subtree back to `AGENTS.md` for the duration of the wrapper run,
-then restore them to the disabled state.
+`--agents` rename matching `AGENTS.md.disabled` and `.agents.disabled` entries
+under the current `PWD` subtree back to their enabled names and leave them
+enabled.
 
-`--skills` temporarily rename matching `.codex.disabled`, `skills.disabled`,
-and `SKILLS.disabled` entries under the current `PWD` subtree back to their
-enabled names for the duration of the wrapper run, then restore them to the
-disabled state.
+`--skills` rename matching `.agents.disabled`, `.codex.disabled`,
+`skills.disabled`, and `SKILLS.disabled` entries under the current `PWD`
+subtree back to their enabled names and leave them enabled.
 
 `--skags` is shorthand for enabling both AGENTS and skill sources for the same
 run.
 
-`--no-agents` temporarily rename matching `AGENTS.md` entries under the current
-`PWD` subtree to `AGENTS.md.disabled` for the duration of the wrapper run, then
-restore them.
+`--no-agents` rename matching `AGENTS.md` and `.agents` entries under the
+current `PWD` subtree to `*.disabled` and leave them disabled.
 
-`--no-skills` temporarily rename matching `.codex`, `skills`, and `SKILLS`
-entries under the current `PWD` subtree to `*.disabled` for the duration of the
-wrapper run, then restore them.
+`--no-skills` rename matching `.agents`, `.codex`, `skills`, and `SKILLS`
+entries under the current `PWD` subtree to `*.disabled` and leave them
+disabled.
 
 `--no-skags` is shorthand for disabling both AGENTS and skill sources for the
 same run.
 
-Default behavior: if `AGENTS.md.disabled`, `.codex.disabled`,
-`skills.disabled`, or `SKILLS.disabled` already exist under `PWD`, the wrapper
-will enable them for that run before launching Codex.
+Default behavior: if `AGENTS.md.disabled`, `.agents.disabled`,
+`.codex.disabled`, `skills.disabled`, or `SKILLS.disabled` already exist under
+`PWD`, the wrapper enables them before launching Codex and leaves them enabled.
 
 To keep workflow sources off for a specific run, you must explicitly pass
 `--no-agents`, `--no-skills`, or `--no-skags`.
 
 If matching `*.disabled` entries already exist under `PWD`, the wrapper treats
-them as enabled by default for that run, prints an enable notice, and restores
-them to the disabled state afterward. Pass `--no-agents`, `--no-skills`, or
-`--no-skags` to keep the matching workflow sources disabled for that run.
+them as enabled by default and renames them back to their enabled names unless
+`--no-agents`, `--no-skills`, or `--no-skags` keeps that category disabled.
 
 ---
 
@@ -368,8 +365,8 @@ codex --rw ~/.local ~/src
 
 ### `--no-agents`
 
-Temporarily disable `AGENTS.md` entries under the current `PWD` subtree for the
-duration of the wrapper run, then restore them.
+Disable `AGENTS.md` and `.agents` entries under the current `PWD` subtree and
+leave them disabled.
 
 ```
 codex --no-agents
@@ -379,8 +376,8 @@ codex --no-agents
 
 ### `--agents`
 
-Temporarily enable `AGENTS.md.disabled` entries under the current `PWD` subtree
-for the duration of the wrapper run, then restore them to the disabled state.
+Enable `AGENTS.md.disabled` and `.agents.disabled` entries under the current
+`PWD` subtree and leave them enabled.
 
 ```
 codex --agents
@@ -390,8 +387,8 @@ codex --agents
 
 ### `--no-skills`
 
-Temporarily disable `.codex`, `skills`, and `SKILLS` entries under the current
-`PWD` subtree for the duration of the wrapper run, then restore them.
+Disable `.agents`, `.codex`, `skills`, and `SKILLS` entries under the current
+`PWD` subtree and leave them disabled.
 
 ```
 codex --no-skills
@@ -401,9 +398,9 @@ codex --no-skills
 
 ### `--skills`
 
-Temporarily enable `.codex.disabled`, `skills.disabled`, and `SKILLS.disabled`
-entries under the current `PWD` subtree for the duration of the wrapper run,
-then restore them to the disabled state.
+Enable `.agents.disabled`, `.codex.disabled`, `skills.disabled`, and
+`SKILLS.disabled` entries under the current `PWD` subtree and leave them
+enabled.
 
 ```
 codex --skills

--- a/SESSION.md
+++ b/SESSION.md
@@ -1,15 +1,15 @@
 # SESSION
 
 Session Start: 2026-04-08 10:41 CDT
-Session End: 2026-04-08 13:13 CDT
+Session End: 2026-04-12 09:44 CDT
 Session Status: active
 
-Branch: main
-Active Issue: none
-Stage: pair
-Workflow Step: pair
-Next Skill: review
-Active Lanes: docs, test
+Branch: feat/9-cover-known-agent-skill-sources
+Active Issue: #9
+Stage: delivery preparation
+Workflow Step: deliver
+Next Skill: merge
+Active Lanes: src, test, docs
 
 Repository State: modified
 Validation Status: complete
@@ -22,42 +22,49 @@ Source Of Truth:
 - docs/AGENTS.md
 
 Current Goal:
-Fix installer behavior so a normal `git clone` followed by `./install.sh` leaves `codex` available from `~/.local/bin` in new Bash, Zsh, and login-shell sessions without manual copying.
+Implement issue `#9` so the wrapper toggle commands cover the known project-local workflow-source set including `.agents`, using persistent state-setting semantics instead of restore-on-exit behavior.
 
 Last Action:
-Extended the installer and uninstall flow to manage POSIX-safe PATH blocks across `.bashrc`, `.zshrc`, `.profile`, `.bash_profile`, and `.zprofile`, updated README wording, and expanded install coverage to verify fresh interactive and login-shell resolution.
+Changed the wrapper, spec, README, and Bats coverage so enable/disable flags set on-disk state persistently, `.agents` participates in both relevant toggle scans, and the wrapper no longer restores names on exit.
 
 Next Step:
-Review the multi-shell install-path fix and decide whether the legacy `--bashrc` flag should be renamed in a later compatibility-preserving slice.
+Push the approved issue `#9` slice and open the PR against `main` with the approved commit and PR text.
 
 Next Action:
-Inspect the final diff, confirm the startup-file wording is acceptable UX, and then either commit or add a compatibility alias for a broader option name.
+Stage the scoped files, commit with the approved message, push `feat/9-cover-known-agent-skill-sources`, and create the PR that closes `#9`.
 
 Open Decisions:
-- whether the existing `--bashrc` flag name should stay for compatibility or gain a clearer alias such as `--shell-init`
-- whether install docs should recommend `./install.sh --yes --bashrc yes` as the default non-interactive path
+- whether `.agents/` should be treated as part of `--no-agents`, `--no-skills`, or both categories in implementation details; requested outcome is that all three disable commands cover it
+- whether the enable-side flags (`--skills`, `--skags`, possibly `--agents`) should gain matching `.agents.disabled` handling in the same slice or a follow-up issue
 
 Blockers:
 - none
 
 Relevant Spec Clauses:
-- none
+- `SPEC-PARSE-9`
+- `SPEC-PARSE-10`
+- `SPEC-PARSE-11`
+- `SPEC-PARSE-13`
+- `SPEC-PARSE-14`
+- `SPEC-PARSE-15`
+- `SPEC-PARSE-16`
 
 Files In Play:
+- SPEC.md
 - README.md
-- install.sh
-- test/install.bats
+- src/codex_wrapper.sh
 - test/wrapper.bats
 - SESSION.md
 
 Validation Summary:
-- `bash -n install.sh`
-- `bats test/install.bats`
+- `bash -n src/codex_wrapper.sh`
+- `bats test/wrapper.bats`
 
 Operational Notes:
-- installer still writes the wrapper to `~/.local/bin/codex` and uninstall support under `~/.local/share/codex-wrapper/`
-- managed startup content now uses a POSIX-safe PATH prepend block in `.bashrc`, `.zshrc`, `.profile`, `.bash_profile`, and `.zprofile`
-- install coverage now checks command discovery from a fresh interactive Bash shell and a fresh login Bash shell, not just file presence at the target path
+- issue `#9` tracks broadening toggle coverage to the known project-local set: `AGENTS.md`, `.agents`, `.codex`, `skills`, and `SKILLS`, plus matching `.disabled` forms
+- `.agents` is now included in both AGENTS-side and SKILLS-side target scans so `--no-agents`, `--no-skills`, `--agents`, `--skills`, and the combined flags all see it
+- the wrapper now leaves enable/disable renames in place after exit; there is no restore-on-exit behavior
+- because `.agents` participates in both categories, some status banners now report `AGENTS and SKILLS` together where earlier tests only observed one category
 
 Local Exceptions:
 - none

--- a/SPEC.md
+++ b/SPEC.md
@@ -151,14 +151,14 @@ A missing path list after `--ro` or `--rw` is an error.
 
 ### SPEC-PARSE-6
 
-`--agents` requests that `AGENTS.md.disabled` files under the launch directory
-be enabled for the duration of the wrapper run.
+`--agents` requests that `AGENTS.md.disabled` and `.agents.disabled` entries
+under the launch directory be enabled.
 
 ### SPEC-PARSE-7
 
-`--skills` requests that `.codex.disabled`, `skills.disabled`, and
-`SKILLS.disabled` entries under the launch directory be enabled for the
-duration of the wrapper run.
+`--skills` requests that `.agents.disabled`, `.codex.disabled`,
+`skills.disabled`, and `SKILLS.disabled` entries under the launch directory be
+enabled.
 
 ### SPEC-PARSE-8
 
@@ -166,13 +166,13 @@ duration of the wrapper run.
 
 ### SPEC-PARSE-9
 
-`--no-agents` requests that `AGENTS.md` files under the launch directory be
-disabled for the duration of the wrapper run.
+`--no-agents` requests that `AGENTS.md` and `.agents` entries under the launch
+directory be disabled.
 
 ### SPEC-PARSE-10
 
-`--no-skills` requests that `.codex`, `skills`, and `SKILLS` entries under the
-launch directory be disabled for the duration of the wrapper run.
+`--no-skills` requests that `.agents`, `.codex`, `skills`, and `SKILLS`
+entries under the launch directory be disabled.
 
 ### SPEC-PARSE-11
 
@@ -184,9 +184,8 @@ Conflicting enable and disable flags for the same category are errors.
 
 ### SPEC-PARSE-13
 
-Per-run opt-out behavior is explicit: if workflow sources are pre-disabled on
-disk, the wrapper still enables them for the run unless the matching
-`--no-agents`, `--no-skills`, or `--no-skags` flag is passed.
+If workflow sources are pre-disabled on disk, the wrapper enables them unless
+the matching `--no-agents`, `--no-skills`, or `--no-skags` flag is passed.
 
 ### SPEC-PARSE-14
 
@@ -195,26 +194,24 @@ rooted at the current `PWD`.
 
 ### SPEC-PARSE-15
 
-Wrapper enable and disable flags must not leave newly renamed entries behind
-after the wrapper finishes; entries the wrapper enables or disables temporarily
-must be restored to their original names before the function returns.
+Wrapper enable and disable flags update the on-disk state within the launch
+directory subtree rooted at `PWD`; the wrapper does not restore the previous
+names when it exits.
 
 ### SPEC-PARSE-16
 
 If matching `*.disabled` entries already exist under `PWD`, the wrapper must
-detect that state before launch and treat those entries as enabled by default
-for the run unless the matching `--no-*` flag explicitly keeps that category
-disabled.
+detect that state before launch and enable those entries unless the matching
+`--no-*` flag explicitly keeps that category disabled.
 
 ### SPEC-PARSE-17
 
-If the wrapper temporarily enables pre-existing `*.disabled` entries, it must
-restore them to the disabled state when it exits.
+If the wrapper enables pre-existing `*.disabled` entries, it leaves them
+enabled when it exits.
 
 ### SPEC-PARSE-18
 
-If the wrapper temporarily disables enabled entries, it must restore them to
-the enabled state when it exits.
+If the wrapper disables enabled entries, it leaves them disabled when it exits.
 
 ### SPEC-PARSE-19
 

--- a/src/codex_wrapper.sh
+++ b/src/codex_wrapper.sh
@@ -39,11 +39,11 @@ WRAPPER OPTIONS
   --ro=PATH     add one read-only bind for sandboxed run
   --rw PATH...  add one or more read-write binds for sandboxed run
   --rw=PATH     add one read-write bind for sandboxed run
-  --agents      temporarily enable AGENTS.md.disabled entries under PWD
-  --skills      temporarily enable .codex.disabled, skills.disabled, and SKILLS.disabled under PWD
+  --agents      enable AGENTS.md.disabled and .agents.disabled entries under PWD
+  --skills      enable .agents.disabled, .codex.disabled, skills.disabled, and SKILLS.disabled under PWD
   --skags       equivalent to --agents --skills
-  --no-agents   temporarily disable AGENTS.md entries under PWD
-  --no-skills   temporarily disable .codex, skills, and SKILLS under PWD
+  --no-agents   disable AGENTS.md and .agents entries under PWD
+  --no-skills   disable .agents, .codex, skills, and SKILLS under PWD
   --no-skags    equivalent to --no-agents --no-skills
   --help, -h    show this help
   --            stop wrapper parsing; forward rest to codex
@@ -189,16 +189,16 @@ __codex_wrapper_find_targets() {
 	local category=$1
 	case "$category" in
 	agents)
-		find "$PWD" -depth -name 'AGENTS.md' -print0
+		find "$PWD" -depth \( -name 'AGENTS.md' -o -name '.agents' \) -print0
 		;;
 	skills)
-		find "$PWD" -depth \( -name 'skills' -o -name 'SKILLS' -o -name '.codex' \) -print0
+		find "$PWD" -depth \( -name '.agents' -o -name 'skills' -o -name 'SKILLS' -o -name '.codex' \) -print0
 		;;
 	agents_disabled)
-		find "$PWD" -depth -name 'AGENTS.md.disabled' -print0
+		find "$PWD" -depth \( -name 'AGENTS.md.disabled' -o -name '.agents.disabled' \) -print0
 		;;
 	skills_disabled)
-		find "$PWD" -depth \( -name 'skills.disabled' -o -name 'SKILLS.disabled' -o -name '.codex.disabled' \) -print0
+		find "$PWD" -depth \( -name '.agents.disabled' -o -name 'skills.disabled' -o -name 'SKILLS.disabled' -o -name '.codex.disabled' \) -print0
 		;;
 	esac
 }
@@ -216,7 +216,7 @@ __codex_wrapper_scan_disabled_state() {
 	((${#matches[@]})) && skills_disabled_detected=1
 }
 
-__codex_wrapper_temporarily_disable() {
+__codex_wrapper_apply_disable() {
 	local category=$1 path
 	local -a matches=()
 
@@ -224,7 +224,6 @@ __codex_wrapper_temporarily_disable() {
 	for path in "${matches[@]}"; do
 		[[ -e $path && ! -e ${path}.disabled ]] || continue
 		mv -- "$path" "${path}.disabled" || return
-		temporary_disabled_paths+=("$path")
 		case "$category" in
 		agents) agents_disabled_detected=1 ;;
 		skills) skills_disabled_detected=1 ;;
@@ -232,7 +231,7 @@ __codex_wrapper_temporarily_disable() {
 	done
 }
 
-__codex_wrapper_temporarily_enable() {
+__codex_wrapper_apply_enable() {
 	local category=$1 path original
 	local -a matches=()
 
@@ -241,28 +240,7 @@ __codex_wrapper_temporarily_enable() {
 		original=${path%.disabled}
 		[[ -e $path && ! -e $original ]] || continue
 		mv -- "$path" "$original" || return
-		temporary_enabled_paths+=("$original")
 	done
-}
-
-__codex_wrapper_restore_temporarily_disabled() {
-	local idx path
-	for ((idx = ${#temporary_disabled_paths[@]} - 1; idx >= 0; idx--)); do
-		path=${temporary_disabled_paths[idx]}
-		[[ -e ${path}.disabled ]] || continue
-		mv -- "${path}.disabled" "$path" || return
-	done
-	temporary_disabled_paths=()
-}
-
-__codex_wrapper_restore_temporarily_enabled() {
-	local idx path
-	for ((idx = ${#temporary_enabled_paths[@]} - 1; idx >= 0; idx--)); do
-		path=${temporary_enabled_paths[idx]}
-		[[ -e $path && ! -e ${path}.disabled ]] || continue
-		mv -- "$path" "${path}.disabled" || return
-	done
-	temporary_enabled_paths=()
 }
 
 __codex_wrapper_status_notice() {
@@ -290,7 +268,7 @@ __codex_wrapper_enable_notice() {
 	else
 		return 0
 	fi
-	((${#temporary_enabled_paths[@]})) || return 0
+	((enable_agents || enable_skills)) || return 0
 	printf 'codex-wrapper: %s enabled under %s\n' "$label" "$PWD" >&2
 }
 
@@ -521,8 +499,6 @@ codex() {
 
 	local -a ro_paths=() rw_paths=() app_args=() passthrough_args=()
 	local -a codex_prog=()
-	local -a temporary_disabled_paths=()
-	local -a temporary_enabled_paths=()
 	local show_help=0
 
 	__codex_wrapper_parse "$@" || return
@@ -537,36 +513,16 @@ codex() {
 	__codex_wrapper_scan_disabled_state
 	__codex_wrapper_apply_default_enables
 	if ((enable_agents)); then
-		__codex_wrapper_temporarily_enable agents || {
-			local rc=$?
-			__codex_wrapper_restore_temporarily_disabled || true
-			__codex_wrapper_restore_temporarily_enabled || true
-			return "$rc"
-		}
+		__codex_wrapper_apply_enable agents || return
 	fi
 	if ((enable_skills)); then
-		__codex_wrapper_temporarily_enable skills || {
-			local rc=$?
-			__codex_wrapper_restore_temporarily_disabled || true
-			__codex_wrapper_restore_temporarily_enabled || true
-			return "$rc"
-		}
+		__codex_wrapper_apply_enable skills || return
 	fi
 	if ((disable_agents)); then
-		__codex_wrapper_temporarily_disable agents || {
-			local rc=$?
-			__codex_wrapper_restore_temporarily_disabled || true
-			__codex_wrapper_restore_temporarily_enabled || true
-			return "$rc"
-		}
+		__codex_wrapper_apply_disable agents || return
 	fi
 	if ((disable_skills)); then
-		__codex_wrapper_temporarily_disable skills || {
-			local rc=$?
-			__codex_wrapper_restore_temporarily_disabled || true
-			__codex_wrapper_restore_temporarily_enabled || true
-			return "$rc"
-		}
+		__codex_wrapper_apply_disable skills || return
 	fi
 	__codex_wrapper_scan_disabled_state
 	__codex_wrapper_enable_notice
@@ -581,8 +537,6 @@ codex() {
 	rc=$?
 	if ((rc == 0)); then
 		__codex_wrapper_cleanup "$unit"
-		__codex_wrapper_restore_temporarily_disabled || return
-		__codex_wrapper_restore_temporarily_enabled || return
 		return 0
 	fi
 
@@ -592,16 +546,11 @@ codex() {
 		__codex_wrapper_log "sandbox did not start codex; using fallback"
 		__codex_wrapper_cleanup "$unit"
 		__codex_wrapper_fallback
-		rc=$?
-		__codex_wrapper_restore_temporarily_disabled || return
-		__codex_wrapper_restore_temporarily_enabled || return
-		return "$rc"
+		return $?
 	fi
 
 	__codex_wrapper_log "sandbox did start codex; not retrying"
 	__codex_wrapper_cleanup "$unit"
-	__codex_wrapper_restore_temporarily_disabled || return
-	__codex_wrapper_restore_temporarily_enabled || return
 	return "$rc"
 }
 

--- a/test/stubs/codex
+++ b/test/stubs/codex
@@ -12,7 +12,7 @@ done
 
 if [[ -n ${STUB_CODEX_WORKSPACE_SNAPSHOT:-} ]]; then
   find "$PWD" -maxdepth 3 \
-    \( -name 'AGENTS.md' -o -name 'AGENTS.md.disabled' -o -name '.codex' -o -name '.codex.disabled' -o -name 'skills' -o -name 'skills.disabled' -o -name 'SKILLS' -o -name 'SKILLS.disabled' \) \
+    \( -name 'AGENTS.md' -o -name 'AGENTS.md.disabled' -o -name '.agents' -o -name '.agents.disabled' -o -name '.codex' -o -name '.codex.disabled' -o -name 'skills' -o -name 'skills.disabled' -o -name 'SKILLS' -o -name 'SKILLS.disabled' \) \
     | sort >"$STUB_CODEX_WORKSPACE_SNAPSHOT"
 fi
 

--- a/test/wrapper.bats
+++ b/test/wrapper.bats
@@ -225,19 +225,18 @@ stdin_value: <empty>"
       "$(log_file_exists "$TEST_LOG_DIR/codex.args")")"
 }
 
-@test "--no-agents temporarily disables AGENTS.md entries and restores them after launch" {
+@test "--no-agents disables AGENTS.md entries and leaves them disabled after launch" {
   export STUB_SYSTEMD_RUN_INVOKE_COMMAND=1
   export STUB_CODEX_WORKSPACE_SNAPSHOT="$TEST_LOG_DIR/workspace.snapshot"
-  mkdir -p "$TEST_WORKDIR/sub"
+  mkdir -p "$TEST_WORKDIR/sub" "$TEST_WORKDIR/.agents" "$TEST_WORKDIR/.codex"
   : > "$TEST_WORKDIR/AGENTS.md"
   : > "$TEST_WORKDIR/sub/AGENTS.md"
-  mkdir -p "$TEST_WORKDIR/.codex"
   run_wrapper --no-agents -- --help
 
   local snapshot post_state input_value actual_value passed
   snapshot="$(read_log_file "$STUB_CODEX_WORKSPACE_SNAPSHOT")"
   post_state="$(find "$TEST_WORKDIR" -maxdepth 3 \
-    \( -name 'AGENTS.md' -o -name 'AGENTS.md.disabled' -o -name '.codex' -o -name '.codex.disabled' \) \
+    \( -name 'AGENTS.md' -o -name 'AGENTS.md.disabled' -o -name '.agents' -o -name '.agents.disabled' -o -name '.codex' -o -name '.codex.disabled' \) \
     | sort)"
   input_value="argv: codex --no-agents -- --help
 stdin_type: non-tty
@@ -255,41 +254,46 @@ EOF
 
   passed=0
   if [[ $status == 0 ]] &&
-     [[ $output == *"AGENTS disabled under $TEST_WORKDIR"* ]] &&
+     [[ $output == *"AGENTS and SKILLS disabled under $TEST_WORKDIR"* ]] &&
      ! printf '%s\n' "$snapshot" | grep -Fx -- "$TEST_WORKDIR/AGENTS.md" >/dev/null &&
      ! printf '%s\n' "$snapshot" | grep -Fx -- "$TEST_WORKDIR/sub/AGENTS.md" >/dev/null &&
+     ! printf '%s\n' "$snapshot" | grep -Fx -- "$TEST_WORKDIR/.agents" >/dev/null &&
      printf '%s\n' "$snapshot" | grep -Fx -- "$TEST_WORKDIR/AGENTS.md.disabled" >/dev/null &&
      printf '%s\n' "$snapshot" | grep -Fx -- "$TEST_WORKDIR/sub/AGENTS.md.disabled" >/dev/null &&
+     printf '%s\n' "$snapshot" | grep -Fx -- "$TEST_WORKDIR/.agents.disabled" >/dev/null &&
      printf '%s\n' "$snapshot" | grep -Fx -- "$TEST_WORKDIR/.codex" >/dev/null &&
-     printf '%s\n' "$post_state" | grep -Fx -- "$TEST_WORKDIR/AGENTS.md" >/dev/null &&
-     printf '%s\n' "$post_state" | grep -Fx -- "$TEST_WORKDIR/sub/AGENTS.md" >/dev/null &&
-     ! printf '%s\n' "$post_state" | grep -F -- 'AGENTS.md.disabled' >/dev/null &&
+     ! printf '%s\n' "$post_state" | grep -Fx -- "$TEST_WORKDIR/AGENTS.md" >/dev/null &&
+     ! printf '%s\n' "$post_state" | grep -Fx -- "$TEST_WORKDIR/sub/AGENTS.md" >/dev/null &&
+     ! printf '%s\n' "$post_state" | grep -Fx -- "$TEST_WORKDIR/.agents" >/dev/null &&
+     printf '%s\n' "$post_state" | grep -Fx -- "$TEST_WORKDIR/AGENTS.md.disabled" >/dev/null &&
+     printf '%s\n' "$post_state" | grep -Fx -- "$TEST_WORKDIR/sub/AGENTS.md.disabled" >/dev/null &&
+     printf '%s\n' "$post_state" | grep -Fx -- "$TEST_WORKDIR/.agents.disabled" >/dev/null &&
      printf '%s\n' "$post_state" | grep -Fx -- "$TEST_WORKDIR/.codex" >/dev/null; then
     passed=1
   fi
 
   assert_true_report \
-    "--no-agents temporarily disables AGENTS.md entries and restores them after launch" \
+    "--no-agents disables AGENTS.md entries and leaves them disabled after launch" \
     "wrapper invocation" \
     "$input_value" \
     "conditions" \
-    "status equals 0; runtime snapshot shows only AGENTS.md.disabled entries; .codex remains visible; post-run state restores AGENTS.md" \
+    "status equals 0; runtime snapshot shows AGENTS.md and .agents disabled while .codex remains visible, and post-run state keeps AGENTS.md disabled" \
     "record" \
     "$actual_value" \
     "$passed"
 }
 
-@test "--no-skills temporarily disables skill sources and restores them after launch" {
+@test "--no-skills disables skill sources and leaves them disabled after launch" {
   export STUB_SYSTEMD_RUN_INVOKE_COMMAND=1
   export STUB_CODEX_WORKSPACE_SNAPSHOT="$TEST_LOG_DIR/workspace.snapshot"
-  mkdir -p "$TEST_WORKDIR/.codex" "$TEST_WORKDIR/skills" "$TEST_WORKDIR/SKILLS"
+  mkdir -p "$TEST_WORKDIR/.agents" "$TEST_WORKDIR/.codex" "$TEST_WORKDIR/skills" "$TEST_WORKDIR/SKILLS"
   : > "$TEST_WORKDIR/AGENTS.md"
   run_wrapper --no-skills -- --help
 
   local snapshot post_state input_value actual_value passed
   snapshot="$(read_log_file "$STUB_CODEX_WORKSPACE_SNAPSHOT")"
   post_state="$(find "$TEST_WORKDIR" -maxdepth 3 \
-    \( -name 'AGENTS.md' -o -name '.codex' -o -name '.codex.disabled' -o -name 'skills' -o -name 'skills.disabled' -o -name 'SKILLS' -o -name 'SKILLS.disabled' \) \
+    \( -name 'AGENTS.md' -o -name '.agents' -o -name '.agents.disabled' -o -name '.codex' -o -name '.codex.disabled' -o -name 'skills' -o -name 'skills.disabled' -o -name 'SKILLS' -o -name 'SKILLS.disabled' \) \
     | sort)"
   input_value="argv: codex --no-skills -- --help
 stdin_type: non-tty
@@ -307,37 +311,43 @@ EOF
 
   passed=0
   if [[ $status == 0 ]] &&
-     [[ $output == *"SKILLS disabled under $TEST_WORKDIR"* ]] &&
+     [[ $output == *"AGENTS and SKILLS disabled under $TEST_WORKDIR"* ]] &&
      printf '%s\n' "$snapshot" | grep -Fx -- "$TEST_WORKDIR/AGENTS.md" >/dev/null &&
+     ! printf '%s\n' "$snapshot" | grep -Fx -- "$TEST_WORKDIR/.agents" >/dev/null &&
      ! printf '%s\n' "$snapshot" | grep -Fx -- "$TEST_WORKDIR/.codex" >/dev/null &&
      ! printf '%s\n' "$snapshot" | grep -Fx -- "$TEST_WORKDIR/skills" >/dev/null &&
      ! printf '%s\n' "$snapshot" | grep -Fx -- "$TEST_WORKDIR/SKILLS" >/dev/null &&
+     printf '%s\n' "$snapshot" | grep -Fx -- "$TEST_WORKDIR/.agents.disabled" >/dev/null &&
      printf '%s\n' "$snapshot" | grep -Fx -- "$TEST_WORKDIR/.codex.disabled" >/dev/null &&
      printf '%s\n' "$snapshot" | grep -Fx -- "$TEST_WORKDIR/skills.disabled" >/dev/null &&
      printf '%s\n' "$snapshot" | grep -Fx -- "$TEST_WORKDIR/SKILLS.disabled" >/dev/null &&
      printf '%s\n' "$post_state" | grep -Fx -- "$TEST_WORKDIR/AGENTS.md" >/dev/null &&
-     printf '%s\n' "$post_state" | grep -Fx -- "$TEST_WORKDIR/.codex" >/dev/null &&
-     printf '%s\n' "$post_state" | grep -Fx -- "$TEST_WORKDIR/skills" >/dev/null &&
-     printf '%s\n' "$post_state" | grep -Fx -- "$TEST_WORKDIR/SKILLS" >/dev/null &&
-     ! printf '%s\n' "$post_state" | grep -F -- '.disabled' >/dev/null; then
+     ! printf '%s\n' "$post_state" | grep -Fx -- "$TEST_WORKDIR/.agents" >/dev/null &&
+     ! printf '%s\n' "$post_state" | grep -Fx -- "$TEST_WORKDIR/.codex" >/dev/null &&
+     ! printf '%s\n' "$post_state" | grep -Fx -- "$TEST_WORKDIR/skills" >/dev/null &&
+     ! printf '%s\n' "$post_state" | grep -Fx -- "$TEST_WORKDIR/SKILLS" >/dev/null &&
+     printf '%s\n' "$post_state" | grep -Fx -- "$TEST_WORKDIR/.agents.disabled" >/dev/null &&
+     printf '%s\n' "$post_state" | grep -Fx -- "$TEST_WORKDIR/.codex.disabled" >/dev/null &&
+     printf '%s\n' "$post_state" | grep -Fx -- "$TEST_WORKDIR/skills.disabled" >/dev/null &&
+     printf '%s\n' "$post_state" | grep -Fx -- "$TEST_WORKDIR/SKILLS.disabled" >/dev/null; then
     passed=1
   fi
 
   assert_true_report \
-    "--no-skills temporarily disables skill sources and restores them after launch" \
+    "--no-skills disables skill sources and leaves them disabled after launch" \
     "wrapper invocation" \
     "$input_value" \
     "conditions" \
-    "status equals 0; runtime snapshot shows only disabled skill paths; AGENTS.md remains visible; post-run state restores skill paths" \
+    "status equals 0; runtime snapshot shows .agents and skill paths disabled while AGENTS.md remains visible, and the combined disable banner is reported; post-run state keeps skill paths disabled" \
     "record" \
     "$actual_value" \
     "$passed"
 }
 
-@test "--no-skags temporarily disables both AGENTS and skill sources and restores them after launch" {
+@test "--no-skags disables both AGENTS and skill sources and leaves them disabled after launch" {
   export STUB_SYSTEMD_RUN_INVOKE_COMMAND=1
   export STUB_CODEX_WORKSPACE_SNAPSHOT="$TEST_LOG_DIR/workspace.snapshot"
-  mkdir -p "$TEST_WORKDIR/sub" "$TEST_WORKDIR/.codex" "$TEST_WORKDIR/skills"
+  mkdir -p "$TEST_WORKDIR/sub" "$TEST_WORKDIR/.agents" "$TEST_WORKDIR/.codex" "$TEST_WORKDIR/skills"
   : > "$TEST_WORKDIR/AGENTS.md"
   : > "$TEST_WORKDIR/sub/AGENTS.md"
   run_wrapper --no-skags -- --help
@@ -345,7 +355,7 @@ EOF
   local snapshot post_state input_value actual_value passed
   snapshot="$(read_log_file "$STUB_CODEX_WORKSPACE_SNAPSHOT")"
   post_state="$(find "$TEST_WORKDIR" -maxdepth 3 \
-    \( -name 'AGENTS.md' -o -name 'AGENTS.md.disabled' -o -name '.codex' -o -name '.codex.disabled' -o -name 'skills' -o -name 'skills.disabled' \) \
+    \( -name 'AGENTS.md' -o -name 'AGENTS.md.disabled' -o -name '.agents' -o -name '.agents.disabled' -o -name '.codex' -o -name '.codex.disabled' -o -name 'skills' -o -name 'skills.disabled' \) \
     | sort)"
   input_value="argv: codex --no-skags -- --help
 stdin_type: non-tty
@@ -366,34 +376,41 @@ EOF
      [[ $output == *"AGENTS and SKILLS disabled under $TEST_WORKDIR"* ]] &&
      printf '%s\n' "$snapshot" | grep -Fx -- "$TEST_WORKDIR/AGENTS.md.disabled" >/dev/null &&
      printf '%s\n' "$snapshot" | grep -Fx -- "$TEST_WORKDIR/sub/AGENTS.md.disabled" >/dev/null &&
+     printf '%s\n' "$snapshot" | grep -Fx -- "$TEST_WORKDIR/.agents.disabled" >/dev/null &&
      printf '%s\n' "$snapshot" | grep -Fx -- "$TEST_WORKDIR/.codex.disabled" >/dev/null &&
      printf '%s\n' "$snapshot" | grep -Fx -- "$TEST_WORKDIR/skills.disabled" >/dev/null &&
      ! printf '%s\n' "$snapshot" | grep -Fx -- "$TEST_WORKDIR/AGENTS.md" >/dev/null &&
+     ! printf '%s\n' "$snapshot" | grep -Fx -- "$TEST_WORKDIR/.agents" >/dev/null &&
      ! printf '%s\n' "$snapshot" | grep -Fx -- "$TEST_WORKDIR/.codex" >/dev/null &&
      ! printf '%s\n' "$snapshot" | grep -Fx -- "$TEST_WORKDIR/skills" >/dev/null &&
-     printf '%s\n' "$post_state" | grep -Fx -- "$TEST_WORKDIR/AGENTS.md" >/dev/null &&
-     printf '%s\n' "$post_state" | grep -Fx -- "$TEST_WORKDIR/sub/AGENTS.md" >/dev/null &&
-     printf '%s\n' "$post_state" | grep -Fx -- "$TEST_WORKDIR/.codex" >/dev/null &&
-     printf '%s\n' "$post_state" | grep -Fx -- "$TEST_WORKDIR/skills" >/dev/null &&
-     ! printf '%s\n' "$post_state" | grep -F -- '.disabled' >/dev/null; then
+     ! printf '%s\n' "$post_state" | grep -Fx -- "$TEST_WORKDIR/AGENTS.md" >/dev/null &&
+     ! printf '%s\n' "$post_state" | grep -Fx -- "$TEST_WORKDIR/sub/AGENTS.md" >/dev/null &&
+     ! printf '%s\n' "$post_state" | grep -Fx -- "$TEST_WORKDIR/.agents" >/dev/null &&
+     ! printf '%s\n' "$post_state" | grep -Fx -- "$TEST_WORKDIR/.codex" >/dev/null &&
+     ! printf '%s\n' "$post_state" | grep -Fx -- "$TEST_WORKDIR/skills" >/dev/null &&
+     printf '%s\n' "$post_state" | grep -Fx -- "$TEST_WORKDIR/AGENTS.md.disabled" >/dev/null &&
+     printf '%s\n' "$post_state" | grep -Fx -- "$TEST_WORKDIR/sub/AGENTS.md.disabled" >/dev/null &&
+     printf '%s\n' "$post_state" | grep -Fx -- "$TEST_WORKDIR/.agents.disabled" >/dev/null &&
+     printf '%s\n' "$post_state" | grep -Fx -- "$TEST_WORKDIR/.codex.disabled" >/dev/null &&
+     printf '%s\n' "$post_state" | grep -Fx -- "$TEST_WORKDIR/skills.disabled" >/dev/null; then
     passed=1
   fi
 
   assert_true_report \
-    "--no-skags temporarily disables both AGENTS and skill sources and restores them after launch" \
+    "--no-skags disables both AGENTS and skill sources and leaves them disabled after launch" \
     "wrapper invocation" \
     "$input_value" \
     "conditions" \
-    "status equals 0; runtime snapshot shows disabled AGENTS and skill paths; post-run state restores both sets" \
+    "status equals 0; runtime snapshot shows disabled AGENTS, .agents, and skill paths; post-run state keeps both sets disabled" \
     "record" \
     "$actual_value" \
     "$passed"
 }
 
-@test "--agents temporarily enables disabled AGENTS entries and restores them after launch" {
+@test "--agents enables disabled AGENTS entries and leaves them enabled after launch" {
   export STUB_SYSTEMD_RUN_INVOKE_COMMAND=1
   export STUB_CODEX_WORKSPACE_SNAPSHOT="$TEST_LOG_DIR/workspace.snapshot"
-  mkdir -p "$TEST_WORKDIR/sub" "$TEST_WORKDIR/.codex.disabled"
+  mkdir -p "$TEST_WORKDIR/sub" "$TEST_WORKDIR/.codex.disabled" "$TEST_WORKDIR/.agents.disabled"
   : > "$TEST_WORKDIR/AGENTS.md.disabled"
   : > "$TEST_WORKDIR/sub/AGENTS.md.disabled"
   run_wrapper --agents -- --help
@@ -401,7 +418,7 @@ EOF
   local snapshot post_state input_value actual_value passed
   snapshot="$(read_log_file "$STUB_CODEX_WORKSPACE_SNAPSHOT")"
   post_state="$(find "$TEST_WORKDIR" -maxdepth 3 \
-    \( -name 'AGENTS.md' -o -name 'AGENTS.md.disabled' -o -name '.codex' -o -name '.codex.disabled' \) \
+    \( -name 'AGENTS.md' -o -name 'AGENTS.md.disabled' -o -name '.agents' -o -name '.agents.disabled' -o -name '.codex' -o -name '.codex.disabled' \) \
     | sort)"
   input_value="argv: codex --agents -- --help
 stdin_type: non-tty
@@ -422,41 +439,45 @@ EOF
      [[ $output == *"AGENTS and SKILLS enabled under $TEST_WORKDIR"* ]] &&
      printf '%s\n' "$snapshot" | grep -Fx -- "$TEST_WORKDIR/AGENTS.md" >/dev/null &&
      printf '%s\n' "$snapshot" | grep -Fx -- "$TEST_WORKDIR/sub/AGENTS.md" >/dev/null &&
+     printf '%s\n' "$snapshot" | grep -Fx -- "$TEST_WORKDIR/.agents" >/dev/null &&
      printf '%s\n' "$snapshot" | grep -Fx -- "$TEST_WORKDIR/.codex" >/dev/null &&
      ! printf '%s\n' "$snapshot" | grep -Fx -- "$TEST_WORKDIR/AGENTS.md.disabled" >/dev/null &&
      ! printf '%s\n' "$snapshot" | grep -Fx -- "$TEST_WORKDIR/sub/AGENTS.md.disabled" >/dev/null &&
+     ! printf '%s\n' "$snapshot" | grep -Fx -- "$TEST_WORKDIR/.agents.disabled" >/dev/null &&
      ! printf '%s\n' "$snapshot" | grep -Fx -- "$TEST_WORKDIR/.codex.disabled" >/dev/null &&
-     printf '%s\n' "$post_state" | grep -Fx -- "$TEST_WORKDIR/AGENTS.md.disabled" >/dev/null &&
-     printf '%s\n' "$post_state" | grep -Fx -- "$TEST_WORKDIR/sub/AGENTS.md.disabled" >/dev/null &&
-     printf '%s\n' "$post_state" | grep -Fx -- "$TEST_WORKDIR/.codex.disabled" >/dev/null &&
-     ! printf '%s\n' "$post_state" | grep -Fx -- "$TEST_WORKDIR/AGENTS.md" >/dev/null &&
-     ! printf '%s\n' "$post_state" | grep -Fx -- "$TEST_WORKDIR/sub/AGENTS.md" >/dev/null &&
-     ! printf '%s\n' "$post_state" | grep -Fx -- "$TEST_WORKDIR/.codex" >/dev/null; then
+     printf '%s\n' "$post_state" | grep -Fx -- "$TEST_WORKDIR/AGENTS.md" >/dev/null &&
+     printf '%s\n' "$post_state" | grep -Fx -- "$TEST_WORKDIR/sub/AGENTS.md" >/dev/null &&
+     printf '%s\n' "$post_state" | grep -Fx -- "$TEST_WORKDIR/.agents" >/dev/null &&
+     printf '%s\n' "$post_state" | grep -Fx -- "$TEST_WORKDIR/.codex" >/dev/null &&
+     ! printf '%s\n' "$post_state" | grep -Fx -- "$TEST_WORKDIR/AGENTS.md.disabled" >/dev/null &&
+     ! printf '%s\n' "$post_state" | grep -Fx -- "$TEST_WORKDIR/sub/AGENTS.md.disabled" >/dev/null &&
+     ! printf '%s\n' "$post_state" | grep -Fx -- "$TEST_WORKDIR/.agents.disabled" >/dev/null &&
+     ! printf '%s\n' "$post_state" | grep -Fx -- "$TEST_WORKDIR/.codex.disabled" >/dev/null; then
     passed=1
   fi
 
   assert_true_report \
-    "--agents temporarily enables disabled AGENTS entries and restores them after launch" \
+    "--agents enables disabled AGENTS entries and leaves them enabled after launch" \
     "wrapper invocation" \
     "$input_value" \
     "conditions" \
-    "status equals 0; runtime snapshot shows AGENTS enabled and pre-disabled skills also enabled by default; post-run state restores disabled entries" \
+    "status equals 0; runtime snapshot shows AGENTS and .agents enabled and pre-disabled skills also enabled by default; post-run state keeps those entries enabled" \
     "record" \
     "$actual_value" \
     "$passed"
 }
 
-@test "--skills temporarily enables disabled skill sources and restores them after launch" {
+@test "--skills enables disabled skill sources and leaves them enabled after launch" {
   export STUB_SYSTEMD_RUN_INVOKE_COMMAND=1
   export STUB_CODEX_WORKSPACE_SNAPSHOT="$TEST_LOG_DIR/workspace.snapshot"
   : > "$TEST_WORKDIR/AGENTS.md.disabled"
-  mkdir -p "$TEST_WORKDIR/.codex.disabled" "$TEST_WORKDIR/skills.disabled" "$TEST_WORKDIR/SKILLS.disabled"
+  mkdir -p "$TEST_WORKDIR/.agents.disabled" "$TEST_WORKDIR/.codex.disabled" "$TEST_WORKDIR/skills.disabled" "$TEST_WORKDIR/SKILLS.disabled"
   run_wrapper --skills -- --help
 
   local snapshot post_state input_value actual_value passed
   snapshot="$(read_log_file "$STUB_CODEX_WORKSPACE_SNAPSHOT")"
   post_state="$(find "$TEST_WORKDIR" -maxdepth 3 \
-    \( -name 'AGENTS.md' -o -name 'AGENTS.md.disabled' -o -name '.codex' -o -name '.codex.disabled' -o -name 'skills' -o -name 'skills.disabled' -o -name 'SKILLS' -o -name 'SKILLS.disabled' \) \
+    \( -name 'AGENTS.md' -o -name 'AGENTS.md.disabled' -o -name '.agents' -o -name '.agents.disabled' -o -name '.codex' -o -name '.codex.disabled' -o -name 'skills' -o -name 'skills.disabled' -o -name 'SKILLS' -o -name 'SKILLS.disabled' \) \
     | sort)"
   input_value="argv: codex --skills -- --help
 stdin_type: non-tty
@@ -476,39 +497,43 @@ EOF
   if [[ $status == 0 ]] &&
      [[ $output == *"AGENTS and SKILLS enabled under $TEST_WORKDIR"* ]] &&
      printf '%s\n' "$snapshot" | grep -Fx -- "$TEST_WORKDIR/AGENTS.md" >/dev/null &&
+     printf '%s\n' "$snapshot" | grep -Fx -- "$TEST_WORKDIR/.agents" >/dev/null &&
      printf '%s\n' "$snapshot" | grep -Fx -- "$TEST_WORKDIR/.codex" >/dev/null &&
      printf '%s\n' "$snapshot" | grep -Fx -- "$TEST_WORKDIR/skills" >/dev/null &&
      printf '%s\n' "$snapshot" | grep -Fx -- "$TEST_WORKDIR/SKILLS" >/dev/null &&
      ! printf '%s\n' "$snapshot" | grep -Fx -- "$TEST_WORKDIR/AGENTS.md.disabled" >/dev/null &&
+     ! printf '%s\n' "$snapshot" | grep -Fx -- "$TEST_WORKDIR/.agents.disabled" >/dev/null &&
      ! printf '%s\n' "$snapshot" | grep -Fx -- "$TEST_WORKDIR/.codex.disabled" >/dev/null &&
      ! printf '%s\n' "$snapshot" | grep -Fx -- "$TEST_WORKDIR/skills.disabled" >/dev/null &&
      ! printf '%s\n' "$snapshot" | grep -Fx -- "$TEST_WORKDIR/SKILLS.disabled" >/dev/null &&
-     printf '%s\n' "$post_state" | grep -Fx -- "$TEST_WORKDIR/AGENTS.md.disabled" >/dev/null &&
-     printf '%s\n' "$post_state" | grep -Fx -- "$TEST_WORKDIR/.codex.disabled" >/dev/null &&
-     printf '%s\n' "$post_state" | grep -Fx -- "$TEST_WORKDIR/skills.disabled" >/dev/null &&
-     printf '%s\n' "$post_state" | grep -Fx -- "$TEST_WORKDIR/SKILLS.disabled" >/dev/null &&
-     ! printf '%s\n' "$post_state" | grep -Fx -- "$TEST_WORKDIR/AGENTS.md" >/dev/null &&
-     ! printf '%s\n' "$post_state" | grep -Fx -- "$TEST_WORKDIR/.codex" >/dev/null &&
-     ! printf '%s\n' "$post_state" | grep -Fx -- "$TEST_WORKDIR/skills" >/dev/null &&
-     ! printf '%s\n' "$post_state" | grep -Fx -- "$TEST_WORKDIR/SKILLS" >/dev/null; then
+     printf '%s\n' "$post_state" | grep -Fx -- "$TEST_WORKDIR/AGENTS.md" >/dev/null &&
+     printf '%s\n' "$post_state" | grep -Fx -- "$TEST_WORKDIR/.agents" >/dev/null &&
+     printf '%s\n' "$post_state" | grep -Fx -- "$TEST_WORKDIR/.codex" >/dev/null &&
+     printf '%s\n' "$post_state" | grep -Fx -- "$TEST_WORKDIR/skills" >/dev/null &&
+     printf '%s\n' "$post_state" | grep -Fx -- "$TEST_WORKDIR/SKILLS" >/dev/null &&
+     ! printf '%s\n' "$post_state" | grep -Fx -- "$TEST_WORKDIR/AGENTS.md.disabled" >/dev/null &&
+     ! printf '%s\n' "$post_state" | grep -Fx -- "$TEST_WORKDIR/.agents.disabled" >/dev/null &&
+     ! printf '%s\n' "$post_state" | grep -Fx -- "$TEST_WORKDIR/.codex.disabled" >/dev/null &&
+     ! printf '%s\n' "$post_state" | grep -Fx -- "$TEST_WORKDIR/skills.disabled" >/dev/null &&
+     ! printf '%s\n' "$post_state" | grep -Fx -- "$TEST_WORKDIR/SKILLS.disabled" >/dev/null; then
     passed=1
   fi
 
   assert_true_report \
-    "--skills temporarily enables disabled skill sources and restores them after launch" \
+    "--skills enables disabled skill sources and leaves them enabled after launch" \
     "wrapper invocation" \
     "$input_value" \
     "conditions" \
-    "status equals 0; runtime snapshot shows skill paths enabled and pre-disabled AGENTS also enabled by default; post-run state restores disabled entries" \
+    "status equals 0; runtime snapshot shows .agents and skill paths enabled and pre-disabled AGENTS also enabled by default; post-run state keeps those entries enabled" \
     "record" \
     "$actual_value" \
     "$passed"
 }
 
-@test "--skags temporarily enables both disabled AGENTS and skill sources and restores them after launch" {
+@test "--skags enables both disabled AGENTS and skill sources and leaves them enabled after launch" {
   export STUB_SYSTEMD_RUN_INVOKE_COMMAND=1
   export STUB_CODEX_WORKSPACE_SNAPSHOT="$TEST_LOG_DIR/workspace.snapshot"
-  mkdir -p "$TEST_WORKDIR/sub" "$TEST_WORKDIR/.codex.disabled" "$TEST_WORKDIR/skills.disabled"
+  mkdir -p "$TEST_WORKDIR/sub" "$TEST_WORKDIR/.agents.disabled" "$TEST_WORKDIR/.codex.disabled" "$TEST_WORKDIR/skills.disabled"
   : > "$TEST_WORKDIR/AGENTS.md.disabled"
   : > "$TEST_WORKDIR/sub/AGENTS.md.disabled"
   run_wrapper --skags -- --help
@@ -516,7 +541,7 @@ EOF
   local snapshot post_state input_value actual_value passed
   snapshot="$(read_log_file "$STUB_CODEX_WORKSPACE_SNAPSHOT")"
   post_state="$(find "$TEST_WORKDIR" -maxdepth 3 \
-    \( -name 'AGENTS.md' -o -name 'AGENTS.md.disabled' -o -name '.codex' -o -name '.codex.disabled' -o -name 'skills' -o -name 'skills.disabled' \) \
+    \( -name 'AGENTS.md' -o -name 'AGENTS.md.disabled' -o -name '.agents' -o -name '.agents.disabled' -o -name '.codex' -o -name '.codex.disabled' -o -name 'skills' -o -name 'skills.disabled' \) \
     | sort)"
   input_value="argv: codex --skags -- --help
 stdin_type: non-tty
@@ -537,25 +562,29 @@ EOF
      [[ $output == *"AGENTS and SKILLS enabled under $TEST_WORKDIR"* ]] &&
      printf '%s\n' "$snapshot" | grep -Fx -- "$TEST_WORKDIR/AGENTS.md" >/dev/null &&
      printf '%s\n' "$snapshot" | grep -Fx -- "$TEST_WORKDIR/sub/AGENTS.md" >/dev/null &&
+     printf '%s\n' "$snapshot" | grep -Fx -- "$TEST_WORKDIR/.agents" >/dev/null &&
      printf '%s\n' "$snapshot" | grep -Fx -- "$TEST_WORKDIR/.codex" >/dev/null &&
      printf '%s\n' "$snapshot" | grep -Fx -- "$TEST_WORKDIR/skills" >/dev/null &&
      ! printf '%s\n' "$snapshot" | grep -F -- '.disabled' >/dev/null &&
-     printf '%s\n' "$post_state" | grep -Fx -- "$TEST_WORKDIR/AGENTS.md.disabled" >/dev/null &&
-     printf '%s\n' "$post_state" | grep -Fx -- "$TEST_WORKDIR/sub/AGENTS.md.disabled" >/dev/null &&
-     printf '%s\n' "$post_state" | grep -Fx -- "$TEST_WORKDIR/.codex.disabled" >/dev/null &&
-     printf '%s\n' "$post_state" | grep -Fx -- "$TEST_WORKDIR/skills.disabled" >/dev/null &&
-     ! printf '%s\n' "$post_state" | grep -Fx -- "$TEST_WORKDIR/AGENTS.md" >/dev/null &&
-     ! printf '%s\n' "$post_state" | grep -Fx -- "$TEST_WORKDIR/.codex" >/dev/null &&
-     ! printf '%s\n' "$post_state" | grep -Fx -- "$TEST_WORKDIR/skills" >/dev/null; then
+     printf '%s\n' "$post_state" | grep -Fx -- "$TEST_WORKDIR/AGENTS.md" >/dev/null &&
+     printf '%s\n' "$post_state" | grep -Fx -- "$TEST_WORKDIR/sub/AGENTS.md" >/dev/null &&
+     printf '%s\n' "$post_state" | grep -Fx -- "$TEST_WORKDIR/.agents" >/dev/null &&
+     printf '%s\n' "$post_state" | grep -Fx -- "$TEST_WORKDIR/.codex" >/dev/null &&
+     printf '%s\n' "$post_state" | grep -Fx -- "$TEST_WORKDIR/skills" >/dev/null &&
+     ! printf '%s\n' "$post_state" | grep -Fx -- "$TEST_WORKDIR/AGENTS.md.disabled" >/dev/null &&
+     ! printf '%s\n' "$post_state" | grep -Fx -- "$TEST_WORKDIR/sub/AGENTS.md.disabled" >/dev/null &&
+     ! printf '%s\n' "$post_state" | grep -Fx -- "$TEST_WORKDIR/.agents.disabled" >/dev/null &&
+     ! printf '%s\n' "$post_state" | grep -Fx -- "$TEST_WORKDIR/.codex.disabled" >/dev/null &&
+     ! printf '%s\n' "$post_state" | grep -Fx -- "$TEST_WORKDIR/skills.disabled" >/dev/null; then
     passed=1
   fi
 
   assert_true_report \
-    "--skags temporarily enables both disabled AGENTS and skill sources and restores them after launch" \
+    "--skags enables both disabled AGENTS and skill sources and leaves them enabled after launch" \
     "wrapper invocation" \
     "$input_value" \
     "conditions" \
-    "status equals 0; runtime snapshot shows AGENTS and skill paths enabled; post-run state restores disabled entries" \
+    "status equals 0; runtime snapshot shows AGENTS, .agents, and skill paths enabled; post-run state keeps those entries enabled" \
     "record" \
     "$actual_value" \
     "$passed"
@@ -584,17 +613,17 @@ stdin_value: <empty>"
     "$actual_value"
 }
 
-@test "pre-disabled AGENTS and SKILLS are auto-enabled without flags and restored after launch" {
+@test "pre-disabled AGENTS and SKILLS are auto-enabled without flags and left enabled after launch" {
   export STUB_SYSTEMD_RUN_INVOKE_COMMAND=1
   export STUB_CODEX_WORKSPACE_SNAPSHOT="$TEST_LOG_DIR/workspace.snapshot"
   : > "$TEST_WORKDIR/AGENTS.md.disabled"
-  mkdir -p "$TEST_WORKDIR/.codex.disabled"
+  mkdir -p "$TEST_WORKDIR/.agents.disabled" "$TEST_WORKDIR/.codex.disabled"
   run_wrapper -- --help
 
   local snapshot post_state input_value actual_value passed
   snapshot="$(read_log_file "$STUB_CODEX_WORKSPACE_SNAPSHOT")"
   post_state="$(find "$TEST_WORKDIR" -maxdepth 3 \
-    \( -name 'AGENTS.md' -o -name 'AGENTS.md.disabled' -o -name '.codex' -o -name '.codex.disabled' \) \
+    \( -name 'AGENTS.md' -o -name 'AGENTS.md.disabled' -o -name '.agents' -o -name '.agents.disabled' -o -name '.codex' -o -name '.codex.disabled' \) \
     | sort)"
   input_value="argv: codex -- --help
 stdin_type: non-tty
@@ -614,22 +643,26 @@ EOF
   if [[ $status == 0 ]] &&
      [[ $output == *"AGENTS and SKILLS enabled under $TEST_WORKDIR"* ]] &&
      printf '%s\n' "$snapshot" | grep -Fx -- "$TEST_WORKDIR/AGENTS.md" >/dev/null &&
+     printf '%s\n' "$snapshot" | grep -Fx -- "$TEST_WORKDIR/.agents" >/dev/null &&
      printf '%s\n' "$snapshot" | grep -Fx -- "$TEST_WORKDIR/.codex" >/dev/null &&
      ! printf '%s\n' "$snapshot" | grep -Fx -- "$TEST_WORKDIR/AGENTS.md.disabled" >/dev/null &&
+     ! printf '%s\n' "$snapshot" | grep -Fx -- "$TEST_WORKDIR/.agents.disabled" >/dev/null &&
      ! printf '%s\n' "$snapshot" | grep -Fx -- "$TEST_WORKDIR/.codex.disabled" >/dev/null &&
-     printf '%s\n' "$post_state" | grep -Fx -- "$TEST_WORKDIR/AGENTS.md.disabled" >/dev/null &&
-     printf '%s\n' "$post_state" | grep -Fx -- "$TEST_WORKDIR/.codex.disabled" >/dev/null &&
-     ! printf '%s\n' "$post_state" | grep -Fx -- "$TEST_WORKDIR/AGENTS.md" >/dev/null &&
-     ! printf '%s\n' "$post_state" | grep -Fx -- "$TEST_WORKDIR/.codex" >/dev/null; then
+     printf '%s\n' "$post_state" | grep -Fx -- "$TEST_WORKDIR/AGENTS.md" >/dev/null &&
+     printf '%s\n' "$post_state" | grep -Fx -- "$TEST_WORKDIR/.agents" >/dev/null &&
+     printf '%s\n' "$post_state" | grep -Fx -- "$TEST_WORKDIR/.codex" >/dev/null &&
+     ! printf '%s\n' "$post_state" | grep -Fx -- "$TEST_WORKDIR/AGENTS.md.disabled" >/dev/null &&
+     ! printf '%s\n' "$post_state" | grep -Fx -- "$TEST_WORKDIR/.agents.disabled" >/dev/null &&
+     ! printf '%s\n' "$post_state" | grep -Fx -- "$TEST_WORKDIR/.codex.disabled" >/dev/null; then
     passed=1
   fi
 
   assert_true_report \
-    "pre-disabled AGENTS and SKILLS are auto-enabled without flags and restored after launch" \
+    "pre-disabled AGENTS and SKILLS are auto-enabled without flags and left enabled after launch" \
     "wrapper invocation" \
     "$input_value" \
     "conditions" \
-    "status equals 0; output reports enabled state; runtime snapshot shows enabled paths; post-run state restores disabled entries" \
+    "status equals 0; output reports enabled state; runtime snapshot shows AGENTS, .agents, and skill paths enabled; post-run state keeps them enabled" \
     "record" \
     "$actual_value" \
     "$passed"
@@ -639,13 +672,13 @@ EOF
   export STUB_SYSTEMD_RUN_INVOKE_COMMAND=1
   export STUB_CODEX_WORKSPACE_SNAPSHOT="$TEST_LOG_DIR/workspace.snapshot"
   : > "$TEST_WORKDIR/AGENTS.md.disabled"
-  mkdir -p "$TEST_WORKDIR/.codex.disabled"
+  mkdir -p "$TEST_WORKDIR/.agents.disabled" "$TEST_WORKDIR/.codex.disabled"
   run_wrapper --no-agents -- --help
 
   local snapshot post_state input_value actual_value passed
   snapshot="$(read_log_file "$STUB_CODEX_WORKSPACE_SNAPSHOT")"
   post_state="$(find "$TEST_WORKDIR" -maxdepth 3 \
-    \( -name 'AGENTS.md' -o -name 'AGENTS.md.disabled' -o -name '.codex' -o -name '.codex.disabled' \) \
+    \( -name 'AGENTS.md' -o -name 'AGENTS.md.disabled' -o -name '.agents' -o -name '.agents.disabled' -o -name '.codex' -o -name '.codex.disabled' \) \
     | sort)"
   input_value="argv: codex --no-agents -- --help
 stdin_type: non-tty
@@ -664,15 +697,19 @@ EOF
   passed=0
   if [[ $status == 0 ]] &&
      [[ $output == *"SKILLS enabled under $TEST_WORKDIR"* ]] &&
-     [[ $output == *"AGENTS disabled under $TEST_WORKDIR"* ]] &&
+     [[ $output == *"AGENTS and SKILLS disabled under $TEST_WORKDIR"* ]] &&
      printf '%s\n' "$snapshot" | grep -Fx -- "$TEST_WORKDIR/AGENTS.md.disabled" >/dev/null &&
+     printf '%s\n' "$snapshot" | grep -Fx -- "$TEST_WORKDIR/.agents.disabled" >/dev/null &&
      printf '%s\n' "$snapshot" | grep -Fx -- "$TEST_WORKDIR/.codex" >/dev/null &&
      ! printf '%s\n' "$snapshot" | grep -Fx -- "$TEST_WORKDIR/AGENTS.md" >/dev/null &&
+     ! printf '%s\n' "$snapshot" | grep -Fx -- "$TEST_WORKDIR/.agents" >/dev/null &&
      ! printf '%s\n' "$snapshot" | grep -Fx -- "$TEST_WORKDIR/.codex.disabled" >/dev/null &&
      printf '%s\n' "$post_state" | grep -Fx -- "$TEST_WORKDIR/AGENTS.md.disabled" >/dev/null &&
-     printf '%s\n' "$post_state" | grep -Fx -- "$TEST_WORKDIR/.codex.disabled" >/dev/null &&
+     printf '%s\n' "$post_state" | grep -Fx -- "$TEST_WORKDIR/.agents.disabled" >/dev/null &&
+     printf '%s\n' "$post_state" | grep -Fx -- "$TEST_WORKDIR/.codex" >/dev/null &&
      ! printf '%s\n' "$post_state" | grep -Fx -- "$TEST_WORKDIR/AGENTS.md" >/dev/null &&
-     ! printf '%s\n' "$post_state" | grep -Fx -- "$TEST_WORKDIR/.codex" >/dev/null; then
+     ! printf '%s\n' "$post_state" | grep -Fx -- "$TEST_WORKDIR/.agents" >/dev/null &&
+     ! printf '%s\n' "$post_state" | grep -Fx -- "$TEST_WORKDIR/.codex.disabled" >/dev/null; then
     passed=1
   fi
 
@@ -681,7 +718,7 @@ EOF
     "wrapper invocation" \
     "$input_value" \
     "conditions" \
-    "status equals 0; output reports AGENTS disabled and SKILLS enabled; runtime snapshot keeps AGENTS disabled and enables skills; post-run state restores disabled entries" \
+    "status equals 0; output reports SKILLS enabled and the combined AGENTS and SKILLS disable banner; runtime snapshot keeps AGENTS and .agents disabled and enables skills; post-run state matches that persisted state" \
     "record" \
     "$actual_value" \
     "$passed"


### PR DESCRIPTION
## Summary

- include `.agents` and `.agents.disabled` in the wrapper's known project-local toggle set
- change `--agents` / `--skills` / `--skags` and `--no-agents` / `--no-skills` / `--no-skags` to set persistent on-disk state instead of restoring names on exit
- align `SPEC.md`, `README.md`, and wrapper tests with the persistent state-setting contract

## Validation

- `bash -n src/codex_wrapper.sh`
- `bats test/wrapper.bats`

Closes #9