### PR TITLE
Add wrapper-managed --profile support

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,6 +18,7 @@ It provides:
 
 * systemd-based sandboxing
 * explicit read/write path control
+* wrapper-scoped profile resolution on the existing `--profile` flag
 * state-setting enable/disable of repo `AGENTS.md` and skill sources
 * automatic interactive vs non-interactive handling
 * safe fallback when sandboxing fails
@@ -52,10 +53,13 @@ Default access in primary mode:
 * `SSH_AUTH_SOCK` is mounted read-only when an SSH agent is available
 * network access is available
 
-Important: the wrapper does **not** automatically mount `~/.ssh`. If you need SSH config files or keys inside the sandbox, add them explicitly:
+Wrapper profiles can override those defaults. For example, `--profile readonly`
+exposes the workspace read-only and `--profile offline` disables network access.
+
+Important: the wrapper does **not** automatically mount `~/.ssh`. If you need SSH config files inside the sandbox, either add them explicitly or use the `ssh` wrapper profile. The wrapper still does **not** auto-mount private keys.
 
 ```
-codex --ro ~/.ssh
+codex --profile ssh
 ```
 
 Use primary mode for normal repo work where you want Codex to move quickly but stay confined to the workspace and any paths you explicitly bind.
@@ -67,7 +71,7 @@ If `systemd-run` fails before Codex actually starts, the wrapper retries without
 ```
 --ask-for-approval on-request
 --sandbox workspace-write
--c sandbox_workspace_write.network_access=true
+-c sandbox_workspace_write.network_access=<true|false>
 --cd <launch-directory>
 ```
 
@@ -76,7 +80,8 @@ This mode is more conservative:
 * Codex is rooted at the launch directory
 * native workspace-write restrictions apply
 * approval is required when Codex decides it should escalate
-* the wrapper does not carry wrapper `--ro` / `--rw` paths into fallback
+* the wrapper does not carry wrapper `--ro` / `--rw` / profile mount rules into fallback
+* `--profile offline` changes fallback network access to `false`
 
 This is the recovery path when `systemd --user` is unavailable or fails to launch the service.
 
@@ -97,7 +102,7 @@ codex --ro /some/reference/path -- --model gpt-5.4 --search
 Use custom mode when you want the wrapper to manage the outer execution boundary while still forwarding native Codex features such as:
 
 * model selection
-* config profiles
+* native Codex profiles
 * web search
 * structured output
 * review subcommands
@@ -171,6 +176,82 @@ codex --rw /path/to/dir /another/path
 ```
 
 These are translated into systemd bind mounts.
+
+#### Wrapper-scoped profiles on `--profile`
+
+The wrapper also consumes the existing `--profile` flag before `--`.
+
+Resolution rules:
+
+* repeated `--profile NAME` values are resolved left-to-right
+* unprefixed names prefer wrapper-scoped built-ins
+* unknown unprefixed names pass through to native Codex unchanged
+* `codex:NAME` forces native passthrough as `--profile NAME`
+* `wrapper:NAME` requires a wrapper profile named `NAME` and fails before launch if missing
+* native Codex profiles keep their original relative order among native profiles
+
+Built-in wrapper profiles:
+
+* `git`
+* `ssh`
+* `worktree`
+* `readonly`
+* `config`
+* `config-wide`
+* `host-context`
+* `offline`
+* `online`
+* `secrets-safe`
+
+User-defined wrapper profiles:
+
+* live at `~/.codex/wrapper-profiles.d/NAME.profile`
+* are consulted after built-ins, so built-in names still win
+* support line-based `ro PATH`, `rw PATH`, `deny PATH_OR_GLOB`, and `network on|off|default`
+* ignore blank lines and `#` comments
+* do not support env passthrough directives in this slice
+
+Profile composition rules:
+
+* profiles are composable and apply left-to-right
+* mount rules accumulate
+* later scalar settings override earlier scalar settings
+* deny rules override both read-only and read-write rules
+* explicit `--ro` / `--rw` override profile defaults unless blocked by `secrets-safe`
+* explicit `--rw` overrides explicit `--ro` for the same canonical path unless blocked by `secrets-safe`
+
+Selected built-in behavior:
+
+* `git` gives the workspace read-write access plus read-only Git and SSH client config
+* `ssh` mounts SSH config and known-hosts and may pass through `SSH_AUTH_SOCK` and `GIT_SSH_COMMAND`
+* `readonly` makes the workspace read-only and turns network off
+* `offline` turns network off
+* `online` turns network on
+* `secrets-safe` denies common credential locations even if a broader parent mount remains visible
+
+Security warning: `ssh` does not automatically mount private keys such as `~/.ssh/id_ed25519`.
+
+Examples:
+
+```
+codex --profile git
+```
+
+```
+codex --profile git --profile reviewer
+```
+
+```
+codex --profile codex:git
+```
+
+```
+codex --profile config-wide --profile secrets-safe
+```
+
+```
+codex --profile readonly --profile online
+```
 
 #### Temporarily toggle repo guidance
 
@@ -717,7 +798,7 @@ This prints:
 ## Limitations
 
 * Requires `systemd --user`
-* Not a container (no network isolation by default)
+* Not a container (network isolation is opt-in with `--profile offline`)
 * Sandbox depends on systemd behavior
 * Fallback mode is less secure
 

--- a/src/codex_wrapper.sh
+++ b/src/codex_wrapper.sh
@@ -39,6 +39,8 @@ WRAPPER OPTIONS
   --ro=PATH     add one read-only bind for sandboxed run
   --rw PATH...  add one or more read-write binds for sandboxed run
   --rw=PATH     add one read-write bind for sandboxed run
+  --profile NAME
+                resolve a wrapper or native codex profile
   --agents      enable AGENTS.md.disabled and .agents.disabled entries under PWD
   --skills      enable .agents.disabled, .codex.disabled, skills.disabled, and SKILLS.disabled under PWD
   --skags       equivalent to --agents --skills
@@ -56,9 +58,13 @@ BEHAVIOR
   - fallback run uses:
       --ask-for-approval on-request
       --sandbox workspace-write
-      -c sandbox_workspace_write.network_access=true
+      -c sandbox_workspace_write.network_access=<true|false>
       --cd <launch-directory>
-  - wrapper --rw PATH applies only to the outer systemd sandbox
+  - wrapper --ro/--rw PATH and wrapper-managed --profile mounts apply only to the outer systemd sandbox
+  - wrapper profiles:
+      unprefixed names prefer wrapper profiles
+      codex:NAME forces native codex passthrough
+      wrapper:NAME requires a wrapper profile
 
 DEBUG
   CODEX_WRAPPER_DEBUG=1 codex
@@ -71,7 +77,7 @@ __codex_wrapper_parse_collect_paths() {
 	shift
 	while (($#)); do
 		case "$1" in
-		-- | --ro | --rw | --ro=* | --rw=* | --agents | --skills | --skags | --no-agents | --no-skills | --no-skags | --help | -h | --wrapper-help | --help-wrapper)
+		-- | --ro | --rw | --ro=* | --rw=* | --profile | --profile=* | --agents | --skills | --skags | --no-agents | --no-skills | --no-skags | --help | -h | --wrapper-help | --help-wrapper)
 			break
 			;;
 		esac
@@ -150,6 +156,22 @@ __codex_wrapper_parse() {
 				return 2
 			}
 			rw_paths+=("${arg#--rw=}")
+			shift
+			;;
+		--profile)
+			(($# >= 2)) || {
+				printf 'codex: missing argument for --profile\n' >&2
+				return 2
+			}
+			__codex_wrapper_resolve_profile_arg "$2" || return
+			shift 2
+			;;
+		--profile=*)
+			[[ -n ${arg#--profile=} ]] || {
+				printf 'codex: empty argument for --profile\n' >&2
+				return 2
+			}
+			__codex_wrapper_resolve_profile_arg "${arg#--profile=}" || return
 			shift
 			;;
 		--)
@@ -276,36 +298,426 @@ __codex_wrapper_exists() { [[ -e $1 || -S $1 ]]; }
 
 __codex_wrapper_canon() { realpath -e -- "$1" 2>/dev/null; }
 
-__codex_wrapper_normalize_paths() {
+__codex_wrapper_builtin_profile_exists() {
+	case "$1" in
+	git | ssh | worktree | readonly | config | config-wide | host-context | offline | online | secrets-safe)
+		return 0
+		;;
+	esac
+	return 1
+}
+
+__codex_wrapper_profile_name_is_safe() {
+	[[ $1 =~ ^[A-Za-z0-9][A-Za-z0-9._-]*$ ]]
+}
+
+__codex_wrapper_user_profile_path() {
+	local name=$1
+	__codex_wrapper_profile_name_is_safe "$name" || return 1
+	printf '%s/.codex/wrapper-profiles.d/%s.profile\n' "$HOME" "$name"
+}
+
+__codex_wrapper_user_profile_exists() {
+	local path=
+	path=$(__codex_wrapper_user_profile_path "$1") || return 1
+	[[ -f $path ]]
+}
+
+__codex_wrapper_profile_exists() {
+	__codex_wrapper_builtin_profile_exists "$1" || __codex_wrapper_user_profile_exists "$1"
+}
+
+__codex_wrapper_apply_profile_mounts() {
+	local mode=$1
+	shift
+	case "$mode" in
+	ro) profile_ro_paths+=("$@") ;;
+	rw) profile_rw_paths+=("$@") ;;
+	deny) deny_path_specs+=("$@") ;;
+	esac
+}
+
+__codex_wrapper_apply_profile_network_policy() {
+	case "$1" in
+	default | on | off)
+		network_policy=$1
+		;;
+	esac
+}
+
+__codex_wrapper_expand_user_profile_path() {
+	local spec=$1
+	case "$spec" in
+	'~')
+		printf '%s\n' "$HOME"
+		;;
+	'~/'*)
+		printf '%s/%s\n' "$HOME" "${spec:2}"
+		;;
+	*)
+		printf '%s\n' "$spec"
+		;;
+	esac
+}
+
+__codex_wrapper_apply_builtin_profile() {
+	case "$1" in
+	worktree)
+		__codex_wrapper_apply_profile_mounts rw "$PWD"
+		__codex_wrapper_apply_profile_mounts ro \
+			"$HOME/.gitconfig" \
+			"$HOME/.config/git" \
+			"/etc/gitconfig" \
+			"/etc/ssl" \
+			"/etc/pki" \
+			"/usr/share/ca-certificates"
+		__codex_wrapper_apply_profile_network_policy on
+		;;
+	readonly)
+		__codex_wrapper_apply_profile_mounts ro "$PWD"
+		__codex_wrapper_apply_profile_network_policy off
+		;;
+	git)
+		__codex_wrapper_apply_profile_mounts rw "$PWD"
+		__codex_wrapper_apply_profile_mounts ro \
+			"$HOME/.gitconfig" \
+			"$HOME/.config/git" \
+			"/etc/gitconfig" \
+			"/etc/ssl" \
+			"/etc/pki" \
+			"/usr/share/ca-certificates" \
+			"$HOME/.ssh/config" \
+			"$HOME/.ssh/known_hosts" \
+			"$HOME/.ssh/known_hosts2" \
+			"/etc/ssh/ssh_config"
+		__codex_wrapper_apply_profile_network_policy on
+		;;
+	ssh)
+		__codex_wrapper_apply_profile_mounts ro \
+			"$HOME/.ssh/config" \
+			"$HOME/.ssh/known_hosts" \
+			"$HOME/.ssh/known_hosts2" \
+			"/etc/ssh" \
+			"/etc/ssl" \
+			"/etc/pki" \
+			"/usr/share/ca-certificates"
+		profile_env_passthroughs+=(SSH_AUTH_SOCK GIT_SSH_COMMAND)
+		__codex_wrapper_apply_profile_network_policy on
+		;;
+	config)
+		__codex_wrapper_apply_profile_mounts ro \
+			"$HOME/.config" \
+			"$HOME/.local/share" \
+			"/etc/os-release" \
+			"/etc/lsb-release" \
+			"/etc/hosts" \
+			"/etc/resolv.conf" \
+			"/etc/nsswitch.conf" \
+			"/etc/ssl" \
+			"/etc/pki"
+		;;
+	config-wide)
+		__codex_wrapper_apply_profile_mounts ro \
+			"/etc" \
+			"/usr/share" \
+			"/usr/local/share" \
+			"$HOME/.config" \
+			"$HOME/.local/share"
+		;;
+	host-context)
+		__codex_wrapper_apply_profile_mounts ro \
+			"/etc/os-release" \
+			"/etc/hostname" \
+			"/etc/hosts" \
+			"/etc/resolv.conf" \
+			"/etc/nsswitch.conf" \
+			"/proc/cpuinfo" \
+			"/proc/meminfo"
+		;;
+	offline)
+		__codex_wrapper_apply_profile_network_policy off
+		;;
+	online)
+		__codex_wrapper_apply_profile_network_policy on
+		;;
+	secrets-safe)
+		__codex_wrapper_apply_profile_mounts deny \
+			"$HOME/.ssh/id_*" \
+			"$HOME/.ssh/*_rsa" \
+			"$HOME/.ssh/*_ed25519" \
+			"$HOME/.ssh/*_ecdsa" \
+			"$HOME/.gnupg" \
+			"$HOME/.aws" \
+			"$HOME/.azure" \
+			"$HOME/.config/gcloud" \
+			"$HOME/.docker/config.json" \
+			"$HOME/.kube" \
+			"$HOME/.netrc" \
+			"$HOME/.npmrc" \
+			"$HOME/.pypirc" \
+			"$HOME/.cargo/credentials" \
+			"$HOME/.cargo/credentials.toml"
+		;;
+	esac
+}
+
+__codex_wrapper_load_user_profile() {
+	local name=$1 path= line= lineno=0 directive= value= spec=
+	path=$(__codex_wrapper_user_profile_path "$name") || return 1
+	[[ -f $path ]] || return 1
+
+	while IFS= read -r line || [[ -n $line ]]; do
+		lineno=$((lineno + 1))
+		line=${line%$'\r'}
+		line=${line#"${line%%[![:space:]]*}"}
+		line=${line%"${line##*[![:space:]]}"}
+		[[ -n $line && ${line:0:1} != "#" ]] || continue
+
+		directive=${line%%[[:space:]]*}
+		value=${line#"$directive"}
+		value=${value#"${value%%[![:space:]]*}"}
+
+		case "$directive" in
+		ro | rw | deny)
+			[[ -n $value ]] || {
+				printf 'codex: invalid wrapper profile %s:%s: missing value for %s\n' "$name" "$lineno" "$directive" >&2
+				return 2
+			}
+			spec=$(__codex_wrapper_expand_user_profile_path "$value")
+			__codex_wrapper_apply_profile_mounts "$directive" "$spec"
+			;;
+		network)
+			case "$value" in
+			default | on | off)
+				__codex_wrapper_apply_profile_network_policy "$value"
+				;;
+			*)
+				printf 'codex: invalid wrapper profile %s:%s: invalid network mode: %s\n' "$name" "$lineno" "$value" >&2
+				return 2
+				;;
+			esac
+			;;
+		*)
+			printf 'codex: invalid wrapper profile %s:%s: unknown directive: %s\n' "$name" "$lineno" "$directive" >&2
+			return 2
+			;;
+		esac
+	done < "$path"
+}
+
+__codex_wrapper_apply_wrapper_profile() {
+	local name=$1
+	if __codex_wrapper_builtin_profile_exists "$name"; then
+		__codex_wrapper_apply_builtin_profile "$name"
+		return
+	fi
+	__codex_wrapper_load_user_profile "$name"
+}
+
+__codex_wrapper_resolve_profile_arg() {
+	local raw=$1 name=
+	case "$raw" in
+	codex:*)
+		name=${raw#codex:}
+		[[ -n $name ]] || {
+			printf 'codex: invalid profile prefix, expected codex:NAME\n' >&2
+			return 2
+		}
+		app_args+=(--profile "$name")
+		;;
+	wrapper:*)
+		name=${raw#wrapper:}
+		[[ -n $name ]] || {
+			printf 'codex: invalid profile prefix, expected wrapper:NAME\n' >&2
+			return 2
+		}
+		__codex_wrapper_profile_exists "$name" || {
+			printf 'codex: unknown wrapper profile: %s\n' "$name" >&2
+			return 2
+		}
+		__codex_wrapper_apply_wrapper_profile "$name"
+		;;
+	*)
+		if __codex_wrapper_profile_exists "$raw"; then
+			__codex_wrapper_apply_wrapper_profile "$raw"
+		else
+			app_args+=(--profile "$raw")
+		fi
+		;;
+	esac
+}
+
+__codex_wrapper_normalize_mounts() {
+	local -n rw_input=$1
+	local -n ro_input=$2
+	local -n rw_output=$3
+	local -n ro_output=$4
+	local label=$5
+	local strict_missing=$6
 	local path resolved
 	local -A seen_rw=() seen_ro=()
-	local -a new_rw=() new_ro=()
 
-	for path in "${rw_paths[@]}"; do
+	rw_output=()
+	ro_output=()
+
+	for path in "${rw_input[@]}"; do
 		resolved=$(__codex_wrapper_canon "$path") || {
-			printf 'codex: rw path does not exist: %s\n' "$path" >&2
-			return 2
+			if [[ $strict_missing == 1 ]]; then
+				if [[ $label == cli ]]; then
+					printf 'codex: rw path does not exist: %s\n' "$path" >&2
+				else
+					printf 'codex: %s rw path does not exist: %s\n' "$label" "$path" >&2
+				fi
+				return 2
+			fi
+			continue
 		}
 		[[ -n ${seen_rw["$resolved"]+x} ]] || {
 			seen_rw["$resolved"]=1
-			new_rw+=("$resolved")
+			rw_output+=("$resolved")
 		}
 	done
 
-	for path in "${ro_paths[@]}"; do
+	for path in "${ro_input[@]}"; do
 		resolved=$(__codex_wrapper_canon "$path") || {
-			printf 'codex: ro path does not exist: %s\n' "$path" >&2
-			return 2
+			if [[ $strict_missing == 1 ]]; then
+				if [[ $label == cli ]]; then
+					printf 'codex: ro path does not exist: %s\n' "$path" >&2
+				else
+					printf 'codex: %s ro path does not exist: %s\n' "$label" "$path" >&2
+				fi
+				return 2
+			fi
+			continue
 		}
 		[[ -n ${seen_rw["$resolved"]+x} ]] && continue
 		[[ -n ${seen_ro["$resolved"]+x} ]] || {
 			seen_ro["$resolved"]=1
-			new_ro+=("$resolved")
+			ro_output+=("$resolved")
+		}
+	done
+}
+
+__codex_wrapper_expand_deny_paths() {
+	local spec path resolved nullglob_was_set=0
+	local -A seen=()
+	denied_paths=()
+
+	if shopt -q nullglob; then
+		nullglob_was_set=1
+	fi
+	shopt -s nullglob
+	for spec in "${deny_path_specs[@]}"; do
+		if [[ $spec == *[\*\?\[]* ]]; then
+			while IFS= read -r path; do
+				[[ -n $path ]] || continue
+				resolved=$(__codex_wrapper_canon "$path") || continue
+				[[ -n ${seen["$resolved"]+x} ]] || {
+					seen["$resolved"]=1
+					denied_paths+=("$resolved")
+				}
+			done < <(compgen -G "$spec")
+			continue
+		fi
+		__codex_wrapper_exists "$spec" || continue
+		resolved=$(__codex_wrapper_canon "$spec") || continue
+		[[ -n ${seen["$resolved"]+x} ]] || {
+			seen["$resolved"]=1
+			denied_paths+=("$resolved")
+		}
+	done
+	if ((nullglob_was_set)); then
+		shopt -s nullglob
+	else
+		shopt -u nullglob
+	fi
+}
+
+__codex_wrapper_path_is_denied() {
+	local path=$1 denied=
+	for denied in "${denied_paths[@]}"; do
+		if [[ $path == "$denied" || $path == "$denied"/* ]]; then
+			return 0
+		fi
+	done
+	return 1
+}
+
+__codex_wrapper_filter_denied_paths() {
+	local path=
+	local -a filtered_rw=() filtered_ro=()
+
+	for path in "${rw_paths[@]}"; do
+		__codex_wrapper_path_is_denied "$path" || filtered_rw+=("$path")
+	done
+	for path in "${ro_paths[@]}"; do
+		__codex_wrapper_path_is_denied "$path" || filtered_ro+=("$path")
+	done
+
+	rw_paths=("${filtered_rw[@]}")
+	ro_paths=("${filtered_ro[@]}")
+}
+
+__codex_wrapper_normalize_paths() {
+	local -a normalized_profile_rw=() normalized_profile_ro=()
+	local -a normalized_cli_rw=() normalized_cli_ro=()
+	local path=
+	local -A cli_ro_set=() final_rw_set=() final_ro_set=()
+
+	__codex_wrapper_normalize_mounts profile_rw_paths profile_ro_paths normalized_profile_rw normalized_profile_ro "profile" 0 || return
+	__codex_wrapper_normalize_mounts rw_paths ro_paths normalized_cli_rw normalized_cli_ro "cli" 1 || return
+	__codex_wrapper_expand_deny_paths
+
+	rw_paths=("${normalized_profile_rw[@]}")
+	ro_paths=("${normalized_profile_ro[@]}")
+
+	for path in "${normalized_cli_ro[@]}"; do
+		cli_ro_set["$path"]=1
+	done
+
+	for path in "${rw_paths[@]}"; do
+		[[ -n ${cli_ro_set["$path"]+x} ]] || final_rw_set["$path"]=1
+	done
+	for path in "${ro_paths[@]}"; do
+		[[ -n ${final_rw_set["$path"]+x} ]] || final_ro_set["$path"]=1
+	done
+	for path in "${normalized_cli_ro[@]}"; do
+		unset "final_rw_set[$path]"
+		final_ro_set["$path"]=1
+	done
+	for path in "${normalized_cli_rw[@]}"; do
+		unset "final_ro_set[$path]"
+		final_rw_set["$path"]=1
+	done
+
+	rw_paths=()
+	ro_paths=()
+	for path in "${normalized_profile_rw[@]}"; do
+		[[ -n ${final_rw_set["$path"]+x} ]] && {
+			rw_paths+=("$path")
+			unset "final_rw_set[$path]"
+		}
+	done
+	for path in "${normalized_profile_ro[@]}"; do
+		[[ -n ${final_ro_set["$path"]+x} ]] && {
+			ro_paths+=("$path")
+			unset "final_ro_set[$path]"
+		}
+	done
+	for path in "${normalized_cli_ro[@]}"; do
+		[[ -n ${final_ro_set["$path"]+x} ]] && {
+			ro_paths+=("$path")
+			unset "final_ro_set[$path]"
+		}
+	done
+	for path in "${normalized_cli_rw[@]}"; do
+		[[ -n ${final_rw_set["$path"]+x} ]] && {
+			rw_paths+=("$path")
+			unset "final_rw_set[$path]"
 		}
 	done
 
-	rw_paths=("${new_rw[@]}")
-	ro_paths=("${new_ro[@]}")
+	__codex_wrapper_filter_denied_paths
 }
 
 __codex_wrapper_require_real_codex() {
@@ -362,7 +774,11 @@ __codex_wrapper_restrained_args() {
 	mapfile -d '' -t base < <(__codex_wrapper_strip_policy_flags "$@")
 	printf '%s\0' --ask-for-approval on-request
 	printf '%s\0' --sandbox workspace-write
-	printf '%s\0' -c sandbox_workspace_write.network_access=true
+	if [[ $network_policy == off ]]; then
+		printf '%s\0' -c sandbox_workspace_write.network_access=false
+	else
+		printf '%s\0' -c sandbox_workspace_write.network_access=true
+	fi
 	printf '%s\0' --cd "$PWD"
 	((${#base[@]})) && printf '%s\0' "${base[@]}"
 	((${#passthrough_args[@]})) && printf '%s\0' "${passthrough_args[@]}"
@@ -374,6 +790,7 @@ __codex_wrapper_unit() {
 
 __codex_wrapper_run_prefix() {
 	local unit=$1 path
+	local pwd_canon default_pwd_mode=rw
 	local -a run=(
 		systemd-run
 		--user
@@ -393,11 +810,10 @@ __codex_wrapper_run_prefix() {
 		-p "PrivateTmp=yes"
 		-p "ProtectSystem=strict"
 		-p "ProtectHome=tmpfs"
-		-p "BindPaths=$PWD"
-		-p "ReadWritePaths=$PWD"
 		-p "BindPaths=$HOME/.codex"
 		-p "ReadWritePaths=$HOME/.codex"
 	)
+	pwd_canon=$(__codex_wrapper_canon "$PWD") || return
 
 	local -a default_ro=(
 		"$HOME/.config/gh"
@@ -417,12 +833,44 @@ __codex_wrapper_run_prefix() {
 	for path in "${rw_paths[@]}"; do
 		run+=(-p "BindPaths=$path" -p "ReadWritePaths=$path")
 	done
+	for path in "${rw_paths[@]}"; do
+		if [[ $path == "$pwd_canon" ]]; then
+			default_pwd_mode=explicit
+			break
+		fi
+	done
+	if [[ $default_pwd_mode != explicit ]]; then
+		for path in "${ro_paths[@]}"; do
+			if [[ $path == "$pwd_canon" ]]; then
+				default_pwd_mode=ro
+				break
+			fi
+		done
+	fi
+	case "$default_pwd_mode" in
+	rw)
+		run+=(-p "BindPaths=$pwd_canon" -p "ReadWritePaths=$pwd_canon")
+		;;
+	ro)
+		run+=(-p "BindReadOnlyPaths=$pwd_canon")
+		;;
+	esac
+	for path in "${denied_paths[@]}"; do
+		run+=(-p "InaccessiblePaths=$path")
+	done
+
+	if [[ $network_policy == off ]]; then
+		run+=(-p "IPAddressDeny=any")
+	fi
 
 	if [[ -n ${SSH_AUTH_SOCK:-} && -S ${SSH_AUTH_SOCK:-} ]]; then
 		run+=(
 			-E "SSH_AUTH_SOCK=$SSH_AUTH_SOCK"
 			-p "BindReadOnlyPaths=$SSH_AUTH_SOCK"
 		)
+	fi
+	if [[ " ${profile_env_passthroughs[*]} " == *" GIT_SSH_COMMAND "* && -n ${GIT_SSH_COMMAND:-} ]]; then
+		run+=(-E "GIT_SSH_COMMAND=$GIT_SSH_COMMAND")
 	fi
 
 	printf '%s\0' "${run[@]}"
@@ -498,7 +946,9 @@ codex() {
 	local skills_disabled_detected=0
 
 	local -a ro_paths=() rw_paths=() app_args=() passthrough_args=()
+	local -a profile_ro_paths=() profile_rw_paths=() deny_path_specs=() denied_paths=() profile_env_passthroughs=()
 	local -a codex_prog=()
+	local network_policy=default
 	local show_help=0
 
 	__codex_wrapper_parse "$@" || return

--- a/test/wrapper.bats
+++ b/test/wrapper.bats
@@ -139,6 +139,499 @@ EOF
     "$passed"
 }
 
+@test "unprefixed wrapper profile wins over native passthrough" {
+  mkdir -p "$TEST_HOME/.ssh"
+  : > "$TEST_HOME/.ssh/config"
+  : > "$TEST_HOME/.ssh/known_hosts"
+  run_wrapper --profile git
+
+  local args_file actual_tail input_value actual_value passed
+  args_file="$TEST_LOG_DIR/systemd-run.args"
+  actual_tail="$(extract_command_tail "$args_file")"
+  input_value="argv: codex --profile git
+stdin_type: non-tty
+stdin_value: <empty>"
+  actual_value="$(cat <<EOF
+command_tail:
+$actual_tail
+ssh_config_mounts: $(extract_option_values "BindReadOnlyPaths=$TEST_HOME/.ssh/config" "$args_file" | wc -l)
+known_hosts_mounts: $(extract_option_values "BindReadOnlyPaths=$TEST_HOME/.ssh/known_hosts" "$args_file" | wc -l)
+EOF
+)"
+
+  passed=0
+  if ! printf '%s\n' "$actual_tail" | grep -Fx -- "--profile" >/dev/null &&
+     [[ $(extract_option_values "BindReadOnlyPaths=$TEST_HOME/.ssh/config" "$args_file" | wc -l) == 1 ]] &&
+     [[ $(extract_option_values "BindReadOnlyPaths=$TEST_HOME/.ssh/known_hosts" "$args_file" | wc -l) == 1 ]]; then
+    passed=1
+  fi
+
+  assert_true_report \
+    "unprefixed wrapper profile wins over native passthrough" \
+    "wrapper invocation" \
+    "$input_value" \
+    "conditions" \
+    "native --profile passthrough absent; git wrapper profile mounts ssh config and known_hosts" \
+    "record" \
+    "$actual_value" \
+    "$passed"
+}
+
+@test "unknown unprefixed profile passes through to codex" {
+  run_wrapper --profile reviewer
+
+  local actual_tail input_value actual_value passed
+  actual_tail="$(extract_command_tail "$TEST_LOG_DIR/systemd-run.args")"
+  input_value="argv: codex --profile reviewer
+stdin_type: non-tty
+stdin_value: <empty>"
+  actual_value="$(printf 'command_tail=\n%s' "$actual_tail")"
+
+  passed=0
+  if printf '%s\n' "$actual_tail" | grep -Fx -- "--profile" >/dev/null &&
+     printf '%s\n' "$actual_tail" | grep -Fx -- "reviewer" >/dev/null; then
+    passed=1
+  fi
+
+  assert_true_report \
+    "unknown unprefixed profile passes through to codex" \
+    "wrapper invocation" \
+    "$input_value" \
+    "conditions" \
+    "native --profile reviewer remains in codex argv" \
+    "record" \
+    "$actual_value" \
+    "$passed"
+}
+
+@test "user-defined wrapper profile applies from ~/.codex/wrapper-profiles.d" {
+  mkdir -p \
+    "$TEST_HOME/.codex/wrapper-profiles.d" \
+    "$TEST_HOME/profile-data/secret" \
+    "$TEST_ROOT/reference"
+  : > "$TEST_HOME/profile-data/file.txt"
+  : > "$TEST_HOME/profile-data/secret/token.txt"
+
+  cat > "$TEST_HOME/.codex/wrapper-profiles.d/reviewer.profile" <<EOF
+ro ~/profile-data
+rw $TEST_ROOT/reference
+deny ~/profile-data/secret
+network off
+EOF
+
+  run_wrapper --profile reviewer
+
+  local args_file actual_tail input_value actual_value passed
+  args_file="$TEST_LOG_DIR/systemd-run.args"
+  actual_tail="$(extract_command_tail "$args_file")"
+  input_value="argv: codex --profile reviewer
+stdin_type: non-tty
+stdin_value: <empty>"
+  actual_value="$(cat <<EOF
+command_tail:
+$actual_tail
+profile_ro_mounts: $(extract_option_values "BindReadOnlyPaths=$TEST_HOME/profile-data" "$args_file" | wc -l)
+profile_rw_bind_mounts: $(extract_option_values "BindPaths=$TEST_ROOT/reference" "$args_file" | wc -l)
+profile_rw_write_mounts: $(extract_option_values "ReadWritePaths=$TEST_ROOT/reference" "$args_file" | wc -l)
+profile_deny_mounts: $(extract_option_values "InaccessiblePaths=$TEST_HOME/profile-data/secret" "$args_file" | wc -l)
+network_deny_mounts: $(extract_option_values "IPAddressDeny=any" "$args_file" | wc -l)
+EOF
+)"
+
+  passed=0
+  if ! printf '%s\n' "$actual_tail" | grep -Fx -- "--profile" >/dev/null &&
+     [[ $(extract_option_values "BindReadOnlyPaths=$TEST_HOME/profile-data" "$args_file" | wc -l) == 1 ]] &&
+     [[ $(extract_option_values "BindPaths=$TEST_ROOT/reference" "$args_file" | wc -l) == 1 ]] &&
+     [[ $(extract_option_values "ReadWritePaths=$TEST_ROOT/reference" "$args_file" | wc -l) == 1 ]] &&
+     [[ $(extract_option_values "InaccessiblePaths=$TEST_HOME/profile-data/secret" "$args_file" | wc -l) == 1 ]] &&
+     [[ $(extract_option_values "IPAddressDeny=any" "$args_file" | wc -l) == 1 ]]; then
+    passed=1
+  fi
+
+  assert_true_report \
+    "user-defined wrapper profile applies from ~/.codex/wrapper-profiles.d" \
+    "wrapper invocation" \
+    "$input_value" \
+    "conditions" \
+    "native passthrough is absent; custom ro/rw/deny/network policy from the profile file is applied" \
+    "record" \
+    "$actual_value" \
+    "$passed"
+}
+
+@test "built-in wrapper profile wins over same-named user profile file" {
+  mkdir -p \
+    "$TEST_HOME/.codex/wrapper-profiles.d" \
+    "$TEST_HOME/.ssh" \
+    "$TEST_ROOT/custom-profile"
+  : > "$TEST_HOME/.ssh/config"
+  : > "$TEST_HOME/.ssh/known_hosts"
+
+  cat > "$TEST_HOME/.codex/wrapper-profiles.d/git.profile" <<EOF
+ro $TEST_ROOT/custom-profile
+network off
+EOF
+
+  run_wrapper --profile git
+
+  local args_file actual_tail input_value actual_value passed
+  args_file="$TEST_LOG_DIR/systemd-run.args"
+  actual_tail="$(extract_command_tail "$args_file")"
+  input_value="argv: codex --profile git
+stdin_type: non-tty
+stdin_value: <empty>"
+  actual_value="$(cat <<EOF
+command_tail:
+$actual_tail
+ssh_config_mounts: $(extract_option_values "BindReadOnlyPaths=$TEST_HOME/.ssh/config" "$args_file" | wc -l)
+custom_profile_mounts: $(extract_option_values "BindReadOnlyPaths=$TEST_ROOT/custom-profile" "$args_file" | wc -l)
+network_deny_mounts: $(extract_option_values "IPAddressDeny=any" "$args_file" | wc -l)
+EOF
+)"
+
+  passed=0
+  if ! printf '%s\n' "$actual_tail" | grep -Fx -- "--profile" >/dev/null &&
+     [[ $(extract_option_values "BindReadOnlyPaths=$TEST_HOME/.ssh/config" "$args_file" | wc -l) == 1 ]] &&
+     [[ $(extract_option_values "BindReadOnlyPaths=$TEST_ROOT/custom-profile" "$args_file" | wc -l) == 0 ]] &&
+     [[ $(extract_option_values "IPAddressDeny=any" "$args_file" | wc -l) == 0 ]]; then
+    passed=1
+  fi
+
+  assert_true_report \
+    "built-in wrapper profile wins over same-named user profile file" \
+    "wrapper invocation" \
+    "$input_value" \
+    "conditions" \
+    "built-in git behavior applies and same-named user profile content is ignored" \
+    "record" \
+    "$actual_value" \
+    "$passed"
+}
+
+@test "codex prefix forces native profile passthrough" {
+  run_wrapper --profile codex:git
+
+  local actual_tail input_value actual_value passed
+  actual_tail="$(extract_command_tail "$TEST_LOG_DIR/systemd-run.args")"
+  input_value="argv: codex --profile codex:git
+stdin_type: non-tty
+stdin_value: <empty>"
+  actual_value="$(printf 'command_tail=\n%s' "$actual_tail")"
+
+  passed=0
+  if printf '%s\n' "$actual_tail" | grep -Fx -- "--profile" >/dev/null &&
+     printf '%s\n' "$actual_tail" | grep -Fx -- "git" >/dev/null &&
+     ! printf '%s\n' "$actual_tail" | grep -Fx -- "codex:git" >/dev/null; then
+    passed=1
+  fi
+
+  assert_true_report \
+    "codex prefix forces native profile passthrough" \
+    "wrapper invocation" \
+    "$input_value" \
+    "conditions" \
+    "native codex receives --profile git and not the prefixed token" \
+    "record" \
+    "$actual_value" \
+    "$passed"
+}
+
+@test "wrapper prefix requires wrapper profile and fails if missing" {
+  run_wrapper --profile wrapper:missing
+
+  local input_value actual_value
+  input_value="argv: codex --profile wrapper:missing
+stdin_type: non-tty
+stdin_value: <empty>"
+  actual_value="$(printf 'status=%s\noutput=\n%s\nsystemd_run_log_exists=%s\ncodex_log_exists=%s' \
+    "$status" \
+    "$output" \
+    "$(log_file_exists "$TEST_LOG_DIR/systemd-run.args")" \
+    "$(log_file_exists "$TEST_LOG_DIR/codex.args")")"
+
+  assert_equal_report \
+    "wrapper prefix requires wrapper profile and fails if missing" \
+    "wrapper invocation" \
+    "$input_value" \
+    "status and output record" \
+    "$(printf 'status=2\noutput=\n%s\nsystemd_run_log_exists=no\ncodex_log_exists=no' "codex: unknown wrapper profile: missing")" \
+    "status and output record" \
+    "$actual_value"
+}
+
+@test "invalid user-defined wrapper profile fails before launch" {
+  mkdir -p "$TEST_HOME/.codex/wrapper-profiles.d"
+  cat > "$TEST_HOME/.codex/wrapper-profiles.d/reviewer.profile" <<EOF
+env SSH_AUTH_SOCK
+EOF
+
+  run_wrapper --profile reviewer
+
+  local input_value actual_value
+  input_value="argv: codex --profile reviewer
+stdin_type: non-tty
+stdin_value: <empty>"
+  actual_value="$(printf 'status=%s\noutput=\n%s\nsystemd_run_log_exists=%s\ncodex_log_exists=%s' \
+    "$status" \
+    "$output" \
+    "$(log_file_exists "$TEST_LOG_DIR/systemd-run.args")" \
+    "$(log_file_exists "$TEST_LOG_DIR/codex.args")")"
+
+  assert_equal_report \
+    "invalid user-defined wrapper profile fails before launch" \
+    "wrapper invocation" \
+    "$input_value" \
+    "status and output record" \
+    "$(printf 'status=2\noutput=\n%s\nsystemd_run_log_exists=no\ncodex_log_exists=no' "codex: invalid wrapper profile reviewer:1: unknown directive: env")" \
+    "status and output record" \
+    "$actual_value"
+}
+
+@test "multiple profiles are resolved left to right" {
+  run_wrapper --profile codex:first --profile git --profile codex:second
+
+  local actual_tail input_value actual_value
+  actual_tail="$(extract_command_tail "$TEST_LOG_DIR/systemd-run.args")"
+  input_value="argv: codex --profile codex:first --profile git --profile codex:second
+stdin_type: non-tty
+stdin_value: <empty>"
+  actual_value="$(printf 'command_tail=\n%s' "$actual_tail")"
+
+  assert_equal_report \
+    "multiple profiles are resolved left to right" \
+    "wrapper invocation" \
+    "$input_value" \
+    "command tail" \
+    "$(cat <<EOF
+$BATS_TEST_DIRNAME/stubs/codex
+exec
+--dangerously-bypass-approvals-and-sandbox
+--profile
+first
+--profile
+second
+EOF
+)" \
+    "command tail" \
+    "$actual_tail"
+}
+
+@test "offline changes fallback codex network config to false" {
+  export STUB_SYSTEMD_RUN_EXIT=1
+  export STUB_SYSTEMCTL_EXEC_PID=0
+  run_wrapper --profile offline -- --help
+
+  local actual_args input_value actual_value passed
+  actual_args="$(read_log_file "$TEST_LOG_DIR/codex.args")"
+  input_value="argv: codex --profile offline -- --help
+stdin_type: non-tty
+stdin_value: <empty>
+stubbed_systemd_run_exit: 1
+stubbed_exec_pid: 0"
+  actual_value="$(printf 'codex_args=\n%s' "$actual_args")"
+
+  passed=0
+  if printf '%s\n' "$actual_args" | grep -Fx -- "sandbox_workspace_write.network_access=false" >/dev/null; then
+    passed=1
+  fi
+
+  assert_true_report \
+    "offline changes fallback codex network config to false" \
+    "wrapper invocation with fallback" \
+    "$input_value" \
+    "conditions" \
+    "fallback codex args include sandbox_workspace_write.network_access=false" \
+    "record" \
+    "$actual_value" \
+    "$passed"
+}
+
+@test "online after offline results in network on" {
+  export STUB_SYSTEMD_RUN_EXIT=1
+  export STUB_SYSTEMCTL_EXEC_PID=0
+  run_wrapper --profile offline --profile online -- --help
+
+  local actual_args input_value actual_value passed
+  actual_args="$(read_log_file "$TEST_LOG_DIR/codex.args")"
+  input_value="argv: codex --profile offline --profile online -- --help
+stdin_type: non-tty
+stdin_value: <empty>
+stubbed_systemd_run_exit: 1
+stubbed_exec_pid: 0"
+  actual_value="$(printf 'codex_args=\n%s' "$actual_args")"
+
+  passed=0
+  if printf '%s\n' "$actual_args" | grep -Fx -- "sandbox_workspace_write.network_access=true" >/dev/null; then
+    passed=1
+  fi
+
+  assert_true_report \
+    "online after offline results in network on" \
+    "wrapper invocation with fallback" \
+    "$input_value" \
+    "conditions" \
+    "later online profile restores sandbox_workspace_write.network_access=true" \
+    "record" \
+    "$actual_value" \
+    "$passed"
+}
+
+@test "offline after online results in network off" {
+  export STUB_SYSTEMD_RUN_EXIT=1
+  export STUB_SYSTEMCTL_EXEC_PID=0
+  run_wrapper --profile online --profile offline -- --help
+
+  local actual_args input_value actual_value passed
+  actual_args="$(read_log_file "$TEST_LOG_DIR/codex.args")"
+  input_value="argv: codex --profile online --profile offline -- --help
+stdin_type: non-tty
+stdin_value: <empty>
+stubbed_systemd_run_exit: 1
+stubbed_exec_pid: 0"
+  actual_value="$(printf 'codex_args=\n%s' "$actual_args")"
+
+  passed=0
+  if printf '%s\n' "$actual_args" | grep -Fx -- "sandbox_workspace_write.network_access=false" >/dev/null; then
+    passed=1
+  fi
+
+  assert_true_report \
+    "offline after online results in network off" \
+    "wrapper invocation with fallback" \
+    "$input_value" \
+    "conditions" \
+    "later offline profile sets sandbox_workspace_write.network_access=false" \
+    "record" \
+    "$actual_value" \
+    "$passed"
+}
+
+@test "secrets-safe deny paths override profile mounts" {
+  mkdir -p "$TEST_HOME/.config/gcloud" "$TEST_HOME/.aws"
+  : > "$TEST_HOME/.config/gcloud/active_config"
+  : > "$TEST_HOME/.aws/credentials"
+  run_wrapper --profile config-wide --profile secrets-safe --ro "$TEST_HOME/.config/gcloud" --rw "$TEST_HOME/.aws"
+
+  local args_file input_value actual_value passed
+  args_file="$TEST_LOG_DIR/systemd-run.args"
+  input_value="argv: codex --profile config-wide --profile secrets-safe --ro $TEST_HOME/.config/gcloud --rw $TEST_HOME/.aws
+stdin_type: non-tty
+stdin_value: <empty>"
+  actual_value="$(cat <<EOF
+config_mounts: $(extract_option_values "BindReadOnlyPaths=$TEST_HOME/.config" "$args_file" | wc -l)
+gcloud_mounts: $(extract_option_values "BindReadOnlyPaths=$TEST_HOME/.config/gcloud" "$args_file" | wc -l)
+aws_bind_mounts: $(extract_option_values "BindPaths=$TEST_HOME/.aws" "$args_file" | wc -l)
+aws_rw_mounts: $(extract_option_values "ReadWritePaths=$TEST_HOME/.aws" "$args_file" | wc -l)
+gcloud_deny_mounts: $(extract_option_values "InaccessiblePaths=$TEST_HOME/.config/gcloud" "$args_file" | wc -l)
+aws_deny_mounts: $(extract_option_values "InaccessiblePaths=$TEST_HOME/.aws" "$args_file" | wc -l)
+EOF
+)"
+
+  passed=0
+  if [[ $(extract_option_values "BindReadOnlyPaths=$TEST_HOME/.config" "$args_file" | wc -l) == 1 ]] &&
+     [[ $(extract_option_values "BindReadOnlyPaths=$TEST_HOME/.config/gcloud" "$args_file" | wc -l) == 0 ]] &&
+     [[ $(extract_option_values "BindPaths=$TEST_HOME/.aws" "$args_file" | wc -l) == 0 ]] &&
+     [[ $(extract_option_values "ReadWritePaths=$TEST_HOME/.aws" "$args_file" | wc -l) == 0 ]] &&
+     [[ $(extract_option_values "InaccessiblePaths=$TEST_HOME/.config/gcloud" "$args_file" | wc -l) == 1 ]] &&
+     [[ $(extract_option_values "InaccessiblePaths=$TEST_HOME/.aws" "$args_file" | wc -l) == 1 ]]; then
+    passed=1
+  fi
+
+  assert_true_report \
+    "secrets-safe deny paths override profile mounts" \
+    "wrapper invocation" \
+    "$input_value" \
+    "conditions" \
+    "broad config mount remains; denied secret paths are not mounted and are marked inaccessible" \
+    "record" \
+    "$actual_value" \
+    "$passed"
+}
+
+@test "user-defined deny glob handles spaces in matched paths" {
+  mkdir -p \
+    "$TEST_HOME/.codex/wrapper-profiles.d" \
+    "$TEST_HOME/profile data/secret one" \
+    "$TEST_HOME/profile data/secret two"
+  : > "$TEST_HOME/profile data/secret one/token.txt"
+  : > "$TEST_HOME/profile data/secret two/token.txt"
+
+  cat > "$TEST_HOME/.codex/wrapper-profiles.d/reviewer.profile" <<EOF
+ro ~/profile data
+deny ~/profile data/secret*
+EOF
+
+  run_wrapper --profile reviewer
+
+  local args_file input_value actual_value passed
+  args_file="$TEST_LOG_DIR/systemd-run.args"
+  input_value="argv: codex --profile reviewer
+stdin_type: non-tty
+stdin_value: <empty>"
+  actual_value="$(cat <<EOF
+profile_ro_mounts: $(extract_option_values "BindReadOnlyPaths=$TEST_HOME/profile data" "$args_file" | wc -l)
+secret_one_ro_mounts: $(extract_option_values "BindReadOnlyPaths=$TEST_HOME/profile data/secret one" "$args_file" | wc -l)
+secret_two_ro_mounts: $(extract_option_values "BindReadOnlyPaths=$TEST_HOME/profile data/secret two" "$args_file" | wc -l)
+secret_one_deny_mounts: $(extract_option_values "InaccessiblePaths=$TEST_HOME/profile data/secret one" "$args_file" | wc -l)
+secret_two_deny_mounts: $(extract_option_values "InaccessiblePaths=$TEST_HOME/profile data/secret two" "$args_file" | wc -l)
+EOF
+)"
+
+  passed=0
+  if [[ $(extract_option_values "BindReadOnlyPaths=$TEST_HOME/profile data" "$args_file" | wc -l) == 1 ]] &&
+     [[ $(extract_option_values "BindReadOnlyPaths=$TEST_HOME/profile data/secret one" "$args_file" | wc -l) == 0 ]] &&
+     [[ $(extract_option_values "BindReadOnlyPaths=$TEST_HOME/profile data/secret two" "$args_file" | wc -l) == 0 ]] &&
+     [[ $(extract_option_values "InaccessiblePaths=$TEST_HOME/profile data/secret one" "$args_file" | wc -l) == 1 ]] &&
+     [[ $(extract_option_values "InaccessiblePaths=$TEST_HOME/profile data/secret two" "$args_file" | wc -l) == 1 ]]; then
+    passed=1
+  fi
+
+  assert_true_report \
+    "user-defined deny glob handles spaces in matched paths" \
+    "wrapper invocation" \
+    "$input_value" \
+    "conditions" \
+    "the parent read-only mount remains while spaced deny-glob matches are filtered and marked inaccessible" \
+    "record" \
+    "$actual_value" \
+    "$passed"
+}
+
+@test "existing ro and rw behavior remains compatible with wrapper profiles" {
+  run_wrapper --profile readonly --rw "$TEST_WORKDIR"
+
+  local args_file input_value actual_value passed
+  args_file="$TEST_LOG_DIR/systemd-run.args"
+  input_value="argv: codex --profile readonly --rw $TEST_WORKDIR
+stdin_type: non-tty
+stdin_value: <empty>"
+  actual_value="$(cat <<EOF
+rw_bind_mounts: $(extract_option_values "BindPaths=$TEST_WORKDIR" "$args_file" | wc -l)
+rw_write_mounts: $(extract_option_values "ReadWritePaths=$TEST_WORKDIR" "$args_file" | wc -l)
+ro_mounts: $(extract_option_values "BindReadOnlyPaths=$TEST_WORKDIR" "$args_file" | wc -l)
+network_deny_mounts: $(extract_option_values "IPAddressDeny=any" "$args_file" | wc -l)
+EOF
+)"
+
+  passed=0
+  if [[ $(extract_option_values "BindPaths=$TEST_WORKDIR" "$args_file" | wc -l) == 1 ]] &&
+     [[ $(extract_option_values "ReadWritePaths=$TEST_WORKDIR" "$args_file" | wc -l) == 1 ]] &&
+     [[ $(extract_option_values "BindReadOnlyPaths=$TEST_WORKDIR" "$args_file" | wc -l) == 0 ]] &&
+     [[ $(extract_option_values "IPAddressDeny=any" "$args_file" | wc -l) == 1 ]]; then
+    passed=1
+  fi
+
+  assert_true_report \
+    "existing ro and rw behavior remains compatible with wrapper profiles" \
+    "wrapper invocation" \
+    "$input_value" \
+    "conditions" \
+    "explicit --rw overrides readonly profile for the workspace while readonly still disables network" \
+    "record" \
+    "$actual_value" \
+    "$passed"
+}
+
 @test "path normalization deduplicates rw and suppresses duplicate ro when same path is rw" {
   mkdir -p "$TEST_ROOT/alpha" "$TEST_ROOT/beta"
   run_wrapper --rw "$TEST_ROOT/alpha" "$TEST_ROOT/alpha" --ro "$TEST_ROOT/alpha" "$TEST_ROOT/beta"


### PR DESCRIPTION
## Summary
- resolve wrapper-scoped profiles on `--profile` before `--`
- load user-defined wrapper profiles from `~/.codex/wrapper-profiles.d`
- apply profile network policy in fallback and fix spaced-path deny glob handling

## Validation
- bash -n src/codex_wrapper.sh
- bats test/wrapper.bats
